### PR TITLE
Add emlang_export.h for global DLL export/import macros

### DIFF
--- a/include/emlang_export.h
+++ b/include/emlang_export.h
@@ -1,0 +1,55 @@
+//===--- emlang_export.h - Global DLL Export/Import Macros ------*- C++ -*-===//
+//
+// Part of the EMLang Project, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Global DLL export/import macros for all EMLang components
+//
+// This file provides a unified DLL export/import system that should be
+// included by all EMLang header files that need to export symbols.
+//===----------------------------------------------------------------------===//
+
+#ifndef EMLANG_EXPORT_H
+#define EMLANG_EXPORT_H
+
+#pragma once
+
+// ======================== DLL Export/Import Macros ========================
+#ifdef _WIN32
+    #ifdef EMLANG_EXPORTS
+        #define EMLANG_API __declspec(dllexport)
+    #elif defined(EMLANG_DLL)
+        #define EMLANG_API __declspec(dllimport)
+    #else
+        #define EMLANG_API
+    #endif
+#else
+    // Unix/Linux platforms
+    #ifdef EMLANG_EXPORTS
+        #define EMLANG_API __attribute__((visibility("default")))
+    #else
+        #define EMLANG_API
+    #endif
+#endif
+
+// ======================== Template Export Helper ========================
+// For template classes that need explicit instantiation
+#ifdef _WIN32
+    #ifdef EMLANG_EXPORTS
+        #define EMLANG_TEMPLATE_API
+    #else
+        #define EMLANG_TEMPLATE_API extern
+    #endif
+#else
+    #define EMLANG_TEMPLATE_API
+#endif
+
+// ======================== C Export/Import Macros ========================
+#ifdef __cplusplus
+    #define EMLANG_C_API extern "C" EMLANG_API
+#else
+    #define EMLANG_C_API EMLANG_API
+#endif
+
+#endif // EMLANG_EXPORT_H


### PR DESCRIPTION
This pull request introduces a new header file, `emlang_export.h`, to standardize DLL export/import macros across the EMLang project. The changes provide a unified mechanism for symbol visibility management on both Windows and Unix/Linux platforms, as well as support for C and template exports.

### Standardization of DLL export/import macros:

* [`include/emlang_export.h`](diffhunk://#diff-0263862f153512094f8a4a2e72a463c93c9c2b85f2b83497be516411226db84aR1-R55): Added global macros (`EMLANG_API`, `EMLANG_TEMPLATE_API`, and `EMLANG_C_API`) to manage symbol visibility for EMLang components, ensuring compatibility across platforms and simplifying the export/import process.