### PR TITLE
AST refactoring and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,92 +52,64 @@ emlang/
 
 ## ✨ Language Features
 
-#### ✅ **Primitive Types**
-```emlang
-// Integer types with explicit sizing
-let byte: int8 = 127;
-let short: int16 = 32767;
-let normal: int32 = 2147483647;
-let large: int64 = 9223372036854775807;
+### **Primitive Types**
 
-// Unsigned variants
-let ubyte: uint8 = 255;
-let ushort: uint16 = 65535;
-let uint: uint32 = 4294967295;
-let ulong: uint64 = 18446744073709551615;
+| Type     | Size   | Description      | Min Value | Max Value |
+|----------|--------|------------------|-----------|-----------|
+| `int8`   | 8-bit  | Signed integer   | -128 | 127 |
+| `int16`  | 16-bit | Signed integer   | -32,768 | 32,767 |
+| `int32`  | 32-bit | Signed integer   | -2,147,483,648 | 2,147,483,647 |
+| `int64`  | 64-bit | Signed integer   | -9,223,372,036,854,775,808 | 9,223,372,036,854,775,807 |
+| `uint8`  | 8-bit  | Unsigned integer | 0 | 255 |
+| `uint16` | 16-bit | Unsigned integer | 0 | 65,535 |
+| `uint32` | 32-bit | Unsigned integer | 0 | 4,294,967,295 |
+| `uint64` | 64-bit | Unsigned integer | 0 | 18,446,744,073,709,551,615 |
+| `float`  | 32-bit | Floating point   | ~-3.4e38 | ~3.4e38 |
+| `double` | 64-bit | Double precision | ~-1.8e308 | ~1.8e308 |
+| `bool`   | 1-bit  | Boolean          | `false` | `true` |
+| `char`   | 8-bit  | Character        | 0 | 255 |
 
-// Floating point precision
-let precision: float = 3.14159;
-let highPrecision: double = 2.718281828459045;
+### **Unicode and String Support**
 
-// Boolean and character types
-let flag: bool = true;
-let character: char = 'A';
-```
+| Feature                | Description | Examples |
+|------------------------|-------------|----------|
+| **Unicode Characters** | Full UTF-8 character support | `'😀'`, `'π'`, `'€'` |
+| **Escape Sequences**   | Standard C-style escapes | `'\n'`, `'\t'`, `'\\'`, `'\"'` |
+| **Unicode Escapes**    | Unicode code point notation | `'\u{03C0}'` (π), `'\u{20AC}'` (€) |
+| **String Literals**    | UTF-8 string support | `"Hello, World!"` |
+| **Path Strings**       | Windows/Unix path support | `"C:\\Users\\Name"` |
+| **Mixed Content**      | Unicode in strings | `"Càf Manü ★ ♠ ♥"` |
 
-#### ✅ **Unicode and String Support**
-```emlang
-// Unicode character literals
-let emoji: char = '😀';
-let greek: char = '\u{03C0}';  // π
-let euro: char = '\u{20AC}';   // €
+### **C-Style Pointer System**
 
-// String literals with escape sequences
-let message: str = "Hello, World!\n";
-let path: str = "C:\\Users\\Name\\Documents";
-let unicode: str = "Café Münü with symbols: ★ ♠ ♥";
-```
+| Feature | Operator | Description | Usage |
+|---------|----------|-------------|-------|
+| **Address-of** | `&` | Gets memory address | `&variable` |
+| **Dereference** | `*` | Accesses value at address | `*pointer` |
+| **Pointer Declaration** | `*` | Declares pointer type | `int32*` |
+| **Multi-level Pointers** | `**` | Pointer to pointer | `int32**` |
+| **Null Pointer** | `null` | Null pointer value | `ptr = null` |
 
-#### ✅ **C-Style Pointer System**
-```emlang
-function pointerDemo(): int32 {
-    let value: int32 = 42;
-    let ptr: int32* = &value;        // Address-of operator
-    let deref: int32 = *ptr;         // Dereference operator
-    
-    // Multi-level pointers
-    let ptrToPtr: int32** = &ptr;
-    let final: int32 = **ptrToPtr;
-    
-    return final;
-}
-```
+### **Function Declarations**
 
-#### ✅ **Function Declarations**
-```emlang
-function fibonacci(n: int32): int32 {
-    if (n <= 1) {
-        return n;
-    }
-    return fibonacci(n-1) + fibonacci(n-2);
-}
+| Feature | Syntax | Description | Example |
+|---------|--------|-------------|---------|
+| **Function Definition** | `function name(): type` | Regular function | `function add(a: int32, b: int32): int32` |
+| **External Functions** | `extern function` | External C functions | `extern function printf(format: str): int32` |
+| **Void Functions** | `: void` | No return value | `function print(): void` |
+| **Parameters** | `name: type` | Typed parameters | `(x: int32, y: float)` |
+| **Return Statement** | `return value` | Function return | `return x + y` |
 
-// External function declarations
-extern function printf(format: str): int32;
-```
+### **Control Flow**
 
-#### ✅ **Control Flow**
-```emlang
-function controlFlow(): void {
-    let x: int32 = 10;
-    
-    // Conditional statements
-    if (x > 5) {
-        // True branch
-    } else {
-        // False branch
-    }
-    
-    // Loop constructs
-    while (x > 0) {
-        x = x - 1;
-    }
-    
-    for (let i: int32 = 0; i < 10; i = i + 1) {
-        // Loop body
-    }
-}
-```
+| Structure | Syntax | Description | Features |
+|-----------|--------|-------------|----------|
+| **If Statement** | `if (condition) { }` | Conditional execution | With optional `else` |
+| **While Loop** | `while (condition) { }` | Pre-condition loop | Condition checked first |
+| **For Loop** | `for (init; condition; update)` | Counting loop | C-style syntax |
+| **Block Scope** | `{ ... }` | Code blocks | Local variable scope |
+| **Nested Structures** | - | All structures nestable | Unlimited nesting depth |
+
 
 ## 🏗️ Architecture & Implementation
 

--- a/compiler/ast/ast_base.cpp
+++ b/compiler/ast/ast_base.cpp
@@ -7,18 +7,27 @@
 // Base AST node implementations
 //===----------------------------------------------------------------------===//
 
-#include "ast.h"
+#include "ast/ast_base.h"
+#include "ast/visitor.h"
 #include <sstream>
 
 namespace emlang {
 
 // ASTNode base class implementation
-ASTNode::ASTNode(ASTNodeType type, size_t line, size_t column)
+ASTNode::ASTNode(NodeType type, size_t line, size_t column)
     : type(type), line(line), column(column) {}
+
+// Expression base class implementation
+Expression::Expression(NodeType type, size_t line, size_t column)
+    : ASTNode(type, line, column) {}
+
+// Statement base class implementation
+Statement::Statement(NodeType type, size_t line, size_t column)
+    : ASTNode(type, line, column) {}
 
 // Program class implementation
 Program::Program(std::vector<StatementPtr> stmts) : 
-    ASTNode(ASTNodeType::PROGRAM, 0, 0), 
+    ASTNode(NodeType::PROGRAM, 0, 0), 
     statements(std::move(stmts)) {}
 
 std::string Program::toString() const {

--- a/compiler/ast/decl.cpp
+++ b/compiler/ast/decl.cpp
@@ -22,7 +22,7 @@ VariableDecl::VariableDecl(
     bool isConst, 
     size_t line, 
     size_t column
-) : Statement(ASTNodeType::VARIABLE_DECLARATION, line, column), 
+) : Statement(NodeType::VARIABLE_DECL, line, column), 
     name(name), 
     type(type), 
     initializer(std::move(init)), 
@@ -30,8 +30,8 @@ VariableDecl::VariableDecl(
 
 std::string VariableDecl::toString() const {
     std::string result = (isConstant ? "const " : "let ") + name;
-    if (!type.empty()) {
-        result += ": " + type;
+    if (type.has_value() && !type->empty()) {
+        result += ": " + type.value();
     }
     if (initializer) {
         result += " = " + initializer->toString();
@@ -49,13 +49,19 @@ FunctionDecl::FunctionDecl(
     std::vector<Parameter> params, 
     const std::string& retType, 
     StatementPtr body, 
+    bool Extern,
+    bool Async,
+    bool Unsafe,
     size_t line, 
     size_t column
-) : Statement(ASTNodeType::FUNCTION_DECLARATION, line, column), 
+) : Statement(NodeType::FUNCTION_DECL, line, column), 
     name(name), 
     parameters(std::move(params)), 
     returnType(retType), 
-    body(std::move(body)) {}
+    body(std::move(body)),
+    isExtern(Extern),
+    isAsync(Async),
+    isUnsafe(Unsafe) {}
 
 std::string FunctionDecl::toString() const {
     std::stringstream ss;
@@ -65,8 +71,8 @@ std::string FunctionDecl::toString() const {
         ss << parameters[i].name << ": " << parameters[i].type;
     }
     ss << ")";
-    if (!returnType.empty()) {
-        ss << ": " << returnType;
+    if (!returnType->empty()) {
+        ss << ": " << returnType.value();
     }
     ss << " " << body->toString() << ")";
     return ss.str();
@@ -83,7 +89,7 @@ ExternFunctionDecl::ExternFunctionDecl(
     const std::string& retType, 
     size_t line, 
     size_t column
-) : Statement(ASTNodeType::EXTERN_FUNCTION_DECLARATION, line, column), 
+) : Statement(NodeType::EXTERN_FN_DECL, line, column), 
     name(name), 
     parameters(std::move(params)), 
     returnType(retType) {}

--- a/compiler/ast/expr.cpp
+++ b/compiler/ast/expr.cpp
@@ -14,10 +14,6 @@
 
 namespace emlang {
 
-// Expression base class
-Expression::Expression(ASTNodeType type, size_t line, size_t column)
-    : ASTNode(type, line, column) {}
-
 // LiteralExpression
 LiteralExpr::LiteralExpr(LiteralType type, const std::string& value, size_t line, size_t column)
     : Expression(ASTNodeType::LITERAL, line, column), literalType(type), value(value) {}

--- a/compiler/ast/expr.cpp
+++ b/compiler/ast/expr.cpp
@@ -16,15 +16,16 @@ namespace emlang {
 
 // LiteralExpression
 LiteralExpr::LiteralExpr(LiteralType type, const std::string& value, size_t line, size_t column)
-    : Expression(ASTNodeType::LITERAL, line, column), literalType(type), value(value) {}
+    : Expression(NodeType::LITERAL_EXPR, line, column), literalType(type), value(value) {}
 
 std::string LiteralExpr::toString() const {
     std::string typeStr;
     switch (literalType) {
-        case LiteralType::NUMBER: typeStr = "NUMBER"; break;
-        case LiteralType::STRING: typeStr = "STRING"; break;
+        case LiteralType::INT: typeStr = "INT"; break;
+        case LiteralType::FLOAT: typeStr = "FLOAT"; break;
+        case LiteralType::STR: typeStr = "STR"; break;
         case LiteralType::CHAR: typeStr = "CHAR"; break;
-        case LiteralType::BOOLEAN: typeStr = "BOOLEAN"; break;
+        case LiteralType::BOOL: typeStr = "BOOL"; break;
         case LiteralType::NULL_LITERAL: typeStr = "NULL"; break;
     }
     return "Literal(" + typeStr + ": " + value + ")";
@@ -36,7 +37,7 @@ void LiteralExpr::accept(ASTVisitor& visitor) {
 
 // IdentifierExpression
 IdentifierExpr::IdentifierExpr(const std::string& name, size_t line, size_t column)
-    : Expression(ASTNodeType::IDENTIFIER, line, column), name(name) {}
+    : Expression(NodeType::IDENTIFIER_EXPR, line, column), name(name) {}
 
 std::string IdentifierExpr::toString() const {
     return "Identifier(" + name + ")";
@@ -47,11 +48,11 @@ void IdentifierExpr::accept(ASTVisitor& visitor) {
 }
 
 // BinaryOpExpression
-BinaryOpExpr::BinaryOpExpr(ExpressionPtr left, const std::string& op, ExpressionPtr right, size_t line, size_t column)
-    : Expression(ASTNodeType::BINARY_OP, line, column), left(std::move(left)), operator_(op), right(std::move(right)) {}
+BinaryOpExpr::BinaryOpExpr(ExpressionPtr left, const BinOp& op, ExpressionPtr right, size_t line, size_t column)
+    : Expression(NodeType::BINARY_EXPR, line, column), left(std::move(left)), operator_(op), right(std::move(right)) {}
 
 std::string BinaryOpExpr::toString() const {
-    return "BinaryOp(" + left->toString() + " " + operator_ + " " + right->toString() + ")";
+    return "BinaryOp(" + left->toString() + " " + binOpToString(operator_) + " " + right->toString() + ")";
 }
 
 void BinaryOpExpr::accept(ASTVisitor& visitor) {
@@ -59,11 +60,11 @@ void BinaryOpExpr::accept(ASTVisitor& visitor) {
 }
 
 // UnaryOpExpression
-UnaryOpExpr::UnaryOpExpr(const std::string& op, ExpressionPtr operand, size_t line, size_t column)
-    : Expression(ASTNodeType::UNARY_OP, line, column), operator_(op), operand(std::move(operand)) {}
+UnaryOpExpr::UnaryOpExpr(const BinaryOpExpr::BinOp& op, ExpressionPtr operand, size_t line, size_t column)
+    : Expression(NodeType::UNARY_EXPR, line, column), operator_(op), operand(std::move(operand)) {}
 
 std::string UnaryOpExpr::toString() const {
-    return "UnaryOp(" + operator_ + operand->toString() + ")";
+    return "UnaryOp(" + binOpToString(operator_) + operand->toString() + ")";
 }
 
 void UnaryOpExpr::accept(ASTVisitor& visitor) {
@@ -72,7 +73,7 @@ void UnaryOpExpr::accept(ASTVisitor& visitor) {
 
 // AssignmentExpression
 AssignmentExpr::AssignmentExpr(ExpressionPtr target, ExpressionPtr value, size_t line, size_t column)
-    : Expression(ASTNodeType::ASSIGNMENT, line, column), target(std::move(target)), value(std::move(value)) {}
+    : Expression(NodeType::ASSIGNMENT_EXPR, line, column), target(std::move(target)), value(std::move(value)) {}
 
 std::string AssignmentExpr::toString() const {
     return "Assignment(" + target->toString() + " = " + value->toString() + ")";
@@ -84,7 +85,7 @@ void AssignmentExpr::accept(ASTVisitor& visitor) {
 
 // FunctionCallExpression
 FunctionCallExpr::FunctionCallExpr(const std::string& name, std::vector<ExpressionPtr> args, size_t line, size_t column)
-    : Expression(ASTNodeType::FUNCTION_CALL, line, column), functionName(name), arguments(std::move(args)) {}
+    : Expression(NodeType::FUNCTION_CALL, line, column), functionName(name), arguments(std::move(args)) {}
 
 std::string FunctionCallExpr::toString() const {
     std::stringstream ss;
@@ -101,9 +102,86 @@ void FunctionCallExpr::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
 
+// MemberExpression
+MemberExpr::MemberExpr(ExpressionPtr object, const std::string& memberName, bool isMethodCall, size_t line, size_t column)
+    : Expression(NodeType::MEMBER_EXPR, line, column), object(std::move(object)), memberName(memberName), isMethodCall(isMethodCall) {}
+
+std::string MemberExpr::toString() const {
+    return "MemberAccess(" + object->toString() + "." + memberName + (isMethodCall ? "()" : "") + ")";
+}
+
+void MemberExpr::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+#ifdef EMLANG_FEATURE_CASTING
+// CastExpression
+CastExpr::CastExpr(ExpressionPtr operand, const std::string& targetType, bool isExplicit, size_t line, size_t column)
+    : Expression(NodeType::CAST_EXPR, line, column), operand(std::move(operand)), targetType(targetType), isExplicit(isExplicit) {}
+
+std::string CastExpr::toString() const {
+    return "Cast(" + operand->toString() + " as " + targetType + ")";
+}
+
+void CastExpr::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+#endif // EMLANG_FEATURE_CASTING
+
+// IndexExpression
+IndexExpr::IndexExpr(ExpressionPtr array, ExpressionPtr index, size_t line, size_t column)
+    : Expression(NodeType::INDEX_EXPR, line, column), array(std::move(array)), index(std::move(index)) {}
+
+std::string IndexExpr::toString() const {
+    return "Index(" + array->toString() + "[" + index->toString() + "])";
+}
+
+void IndexExpr::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+// ArrayExpression
+ArrayExpr::ArrayExpr(std::vector<ExpressionPtr> elements, size_t line, size_t column)
+    : Expression(NodeType::ARRAY_EXPR, line, column), elements(std::move(elements)) {}
+
+std::string ArrayExpr::toString() const {
+    std::stringstream ss;
+    ss << "Array([";
+    for (size_t i = 0; i < elements.size(); ++i) {
+        if (i > 0) ss << ", ";
+        ss << elements[i]->toString();
+    }
+    ss << "])";
+    return ss.str();
+}
+
+void ArrayExpr::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+// ObjectExpression
+ObjectExpr::ObjectExpr(std::vector<ObjectField> fields, size_t line, size_t column)
+    : Expression(NodeType::OBJECT_EXPR, line, column), fields(std::move(fields)) {}
+
+std::string ObjectExpr::toString() const {
+    std::stringstream ss;
+    ss << "Object({";
+    for (size_t i = 0; i < fields.size(); ++i) {
+        if (i > 0) ss << ", ";
+        ss << fields[i].key << ": " << fields[i].value->toString();
+    }
+    ss << "})";
+    return ss.str();
+}
+
+void ObjectExpr::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+#ifdef EMLANG_FEATURE_POINTERS
 // DereferenceExpression
 DereferenceExpr::DereferenceExpr(ExpressionPtr operand, size_t line, size_t column)
-    : Expression(ASTNodeType::DEREFERENCE, line, column), operand(std::move(operand)) {}
+    : Expression(NodeType::DEREFERENCE, line, column), operand(std::move(operand)) {}
 
 std::string DereferenceExpr::toString() const {
     return "Dereference(*" + operand->toString() + ")";
@@ -115,7 +193,7 @@ void DereferenceExpr::accept(ASTVisitor& visitor) {
 
 // AddressOfExpression
 AddressOfExpr::AddressOfExpr(ExpressionPtr operand, size_t line, size_t column)
-    : Expression(ASTNodeType::ADDRESS_OF, line, column), operand(std::move(operand)) {}
+    : Expression(NodeType::ADDRESS_OF, line, column), operand(std::move(operand)) {}
 
 std::string AddressOfExpr::toString() const {
     return "AddressOf(&" + operand->toString() + ")";
@@ -124,5 +202,6 @@ std::string AddressOfExpr::toString() const {
 void AddressOfExpr::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
+#endif // EMLANG_FEATURE_POINTERS
 
 } // namespace emlang

--- a/compiler/ast/stmt.cpp
+++ b/compiler/ast/stmt.cpp
@@ -14,10 +14,6 @@
 
 namespace emlang {
 
-// Statement base class
-Statement::Statement(ASTNodeType type, size_t line, size_t column)
-    : ASTNode(type, line, column) {}
-
 // BlockStatement
 BlockStmt::BlockStmt(std::vector<StatementPtr> stmts, size_t line, size_t column)
     : Statement(ASTNodeType::BLOCK_STATEMENT, line, column), statements(std::move(stmts)) {}

--- a/compiler/ast/stmt.cpp
+++ b/compiler/ast/stmt.cpp
@@ -16,7 +16,7 @@ namespace emlang {
 
 // BlockStatement
 BlockStmt::BlockStmt(std::vector<StatementPtr> stmts, size_t line, size_t column)
-    : Statement(ASTNodeType::BLOCK_STATEMENT, line, column), statements(std::move(stmts)) {}
+    : Statement(NodeType::BLOCK_STMT, line, column), statements(std::move(stmts)) {}
 
 std::string BlockStmt::toString() const {
     std::stringstream ss;
@@ -35,7 +35,7 @@ void BlockStmt::accept(ASTVisitor& visitor) {
 
 // IfStatement
 IfStmt::IfStmt(ExpressionPtr cond, StatementPtr then, StatementPtr else_, size_t line, size_t column)
-    : Statement(ASTNodeType::IF_STATEMENT, line, column), 
+    : Statement(NodeType::IF_STMT, line, column), 
       condition(std::move(cond)), 
       thenBranch(std::move(then)), 
       elseBranch(std::move(else_)) {}
@@ -55,7 +55,7 @@ void IfStmt::accept(ASTVisitor& visitor) {
 
 // WhileStatement
 WhileStmt::WhileStmt(ExpressionPtr cond, StatementPtr body, size_t line, size_t column)
-    : Statement(ASTNodeType::WHILE_STATEMENT, line, column), 
+    : Statement(NodeType::WHILE_STMT, line, column), 
       condition(std::move(cond)), 
       body(std::move(body)) {}
 
@@ -69,7 +69,7 @@ void WhileStmt::accept(ASTVisitor& visitor) {
 
 // ReturnStatement
 ReturnStmt::ReturnStmt(ExpressionPtr val, size_t line, size_t column)
-    : Statement(ASTNodeType::RETURN_STATEMENT, line, column), value(std::move(val)) {}
+    : Statement(NodeType::RETURN_STMT, line, column), value(std::move(val)) {}
 
 std::string ReturnStmt::toString() const {
     if (value) {
@@ -84,13 +84,36 @@ void ReturnStmt::accept(ASTVisitor& visitor) {
 
 // ExpressionStatement
 ExpressionStmt::ExpressionStmt(ExpressionPtr expr, size_t line, size_t column)
-    : Statement(ASTNodeType::EXPRESSION_STMT, line, column), expression(std::move(expr)) {}
+    : Statement(NodeType::EXPRESSION_STMT, line, column), expression(std::move(expr)) {}
 
 std::string ExpressionStmt::toString() const {
     return "ExprStmt(" + expression->toString() + ")";
 }
 
 void ExpressionStmt::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+// ForStatement
+ForStmt::ForStmt(StatementPtr init, ExpressionPtr cond, ExpressionPtr incr, StatementPtr body, size_t line, size_t column)
+    : Statement(NodeType::FOR_STMT, line, column), 
+      initializer(std::move(init)), 
+      condition(std::move(cond)), 
+      increment(std::move(incr)), 
+      body(std::move(body)) {}
+
+std::string ForStmt::toString() const {
+    std::string result = "For(";
+    if (initializer) result += initializer->toString();
+    result += "; ";
+    if (condition) result += condition->toString();
+    result += "; ";
+    if (increment) result += increment->toString();
+    result += "; " + body->toString() + ")";
+    return result;
+}
+
+void ForStmt::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
 

--- a/include/ast/ast_base.h
+++ b/include/ast/ast_base.h
@@ -29,32 +29,47 @@ using ExpressionPtr = std::unique_ptr<Expression>;
 using StatementPtr = std::unique_ptr<Statement>;
 
 /**
- * @enum ASTNodeType
+ * @enum NodeType
  * @brief Enumeration of all AST node types for runtime type identification
  */
-enum class ASTNodeType {
+enum class NodeType {
     // Base types
-    PROGRAM,
+    PROGRAM,         // Root node representing the entire program
     
-    // Expression types
-    LITERAL,
-    IDENTIFIER,
-    BINARY_OP,
-    UNARY_OP,
-    ASSIGNMENT,
-    FUNCTION_CALL,
-    DEREFERENCE,
-    ADDRESS_OF,
+    // Expression
+    LITERAL_EXPR,    // Literal values (numbers, strings, booleans, etc.)
+    IDENTIFIER_EXPR, // Identifier references (variables, functions)
+    BINARY_EXPR,     // Binary operations (e.g., addition, subtraction)
+    UNARY_EXPR,      // Unary operations (e.g., negation, logical NOT)    
+    ASSIGNMENT_EXPR, // Assignment (x = expr)
+    FUNCTION_CALL,   // Function call expressions (func(args))
+    MEMBER_EXPR,     // Member access (obj.member)
+#ifdef EMLANG_FEATURE_CASTING
+    CAST_EXPR,       // Type casting (cast<type>(expr) or foo as <type>)
+#endif
+    INDEX_EXPR,      // Array indexing (arr[index])
+    ARRAY_EXPR,      // Array literals ([1, 2, 3])
+    OBJECT_EXPR,     // Object literals ({key: value})
+#ifdef EMLANG_FEATURE_POINTERS
+    DEREFERENCE,     // Dereference operator (*ptr)
+    ADDRESS_OF,      // Address-of operator (&var)
+#endif
     
-    // Statement types
-    VARIABLE_DECLARATION,
-    FUNCTION_DECLARATION,
-    EXTERN_FUNCTION_DECLARATION,
-    BLOCK_STATEMENT,
-    IF_STATEMENT,
-    WHILE_STATEMENT,
-    RETURN_STATEMENT,
-    EXPRESSION_STMT
+    // Statement
+    IF_STMT,
+    WHILE_STMT,
+    FOR_STMT,
+    RETURN_STMT,
+    BLOCK_STMT,
+    EXPRESSION_STMT,
+
+    // Declarations
+    VARIABLE_DECL,
+    FUNCTION_DECL,
+    EXTERN_FN_DECL,
+#ifdef EMLANG_FEATURE_IMPORTS
+    IMPORT_DECL,      // Import declaration (DO NOT IMPLEMENT YET)
+#endif
 };
 
 /**
@@ -62,10 +77,11 @@ enum class ASTNodeType {
  * @brief Types of literal values supported by the language
  */
 enum class LiteralType {
-    NUMBER,         // Numeric literals (42, 3.14)
-    STRING,         // String literals ("hello")
+    INT,            // Integer literals (42)
+    FLOAT,          // Floating-point literals (3.14)
+    STR,            // String literals ("hello")
     CHAR,           // Character literals ('c')
-    BOOLEAN,        // Boolean literals (true, false)
+    BOOL,           // Boolean literals (true, false)
     NULL_LITERAL    // Null literal
 };
 
@@ -86,11 +102,11 @@ struct Parameter {
  */
 class EMLANG_API ASTNode {
 public:
-    ASTNodeType type;    // Runtime type identification
-    size_t line;         // Source code line number (1-based)
-    size_t column;       // Source code column number (1-based)
+    NodeType type;     // Runtime type identification
+    size_t line;       // Source code line number (1-based)
+    size_t column;     // Source code column number (1-based)
     
-    ASTNode(ASTNodeType type, size_t line = 0, size_t column = 0);
+    ASTNode(NodeType type, size_t line = 0, size_t column = 0);
     virtual ~ASTNode() = default;
     
     virtual std::string toString() const = 0;
@@ -103,7 +119,7 @@ public:
  */
 class EMLANG_API Expression : public ASTNode {
 public:
-    Expression(ASTNodeType type, size_t line = 0, size_t column = 0);
+    Expression(NodeType type, size_t line = 0, size_t column = 0);
     virtual ~Expression() = default;
 };
 
@@ -113,7 +129,7 @@ public:
  */
 class EMLANG_API Statement : public ASTNode {
 public:
-    Statement(ASTNodeType type, size_t line = 0, size_t column = 0);
+    Statement(NodeType type, size_t line = 0, size_t column = 0);
     virtual ~Statement() = default;
 };
 

--- a/include/ast/decl.h
+++ b/include/ast/decl.h
@@ -14,6 +14,7 @@
 
 #include "ast_base.h"
 #include "visitor.h"
+#include <optional>
 
 namespace emlang {
 
@@ -23,12 +24,17 @@ namespace emlang {
  */
 class EMLANG_API VariableDecl : public Statement {
 public:
-    std::string name;           // Variable name
-    std::string type;           // Variable type (optional)
-    ExpressionPtr initializer;  // Optional initializer expression
-    bool isConstant;            // true for const, false for let
+    std::string name;                // Variable name
+    std::optional<std::string> type; // Variable type (optional)
+    ExpressionPtr initializer;       // Optional initializer expression
+    bool isConstant;                 // true for const, false for let
     
-    VariableDecl(const std::string& name, const std::string& type, ExpressionPtr init = nullptr, bool isConst = false, size_t line = 0, size_t column = 0);
+    VariableDecl(
+        const std::string& name, 
+        const std::string& type, 
+        ExpressionPtr init = nullptr, 
+        bool isConst = false, 
+        size_t line = 0, size_t column = 0);
     
     // Delete copy constructor and assignment operator
     VariableDecl(const VariableDecl&) = delete;
@@ -45,15 +51,28 @@ public:
 /**
  * @class FunctionDeclaration
  * @brief Represents function declarations
+ * IMPLEMENT: FunctionDecl -> FnDecl, combine with extern function decl
  */
 class EMLANG_API FunctionDecl : public Statement {
 public:
-    std::string name;                   // Function name
-    std::vector<Parameter> parameters;  // Function parameters
-    std::string returnType;             // Return type (optional)
-    StatementPtr body;                  // Function body
+    std::string name;                      // Function name
+    std::vector<Parameter> parameters;     // Function parameters
+    std::optional<std::string> returnType; // Return type (optional)
+    StatementPtr body;                     // Function body
+    bool isExtern;                         // true if this is an extern function declaration
+    bool isAsync;                          // true if this is an async function declaration
+    bool isUnsafe;                         // true if this is an unsafe function declaration
+    std::optional<std::string> abi;        // ABI name for the function (optional)
     
-    FunctionDecl(const std::string& name, std::vector<Parameter> params, const std::string& retType, StatementPtr body, size_t line = 0, size_t column = 0);
+    FunctionDecl(
+        const std::string& name, 
+        std::vector<Parameter> params, 
+        const std::string& retType, 
+        StatementPtr body, 
+        bool isExtern = false, 
+        bool isAsync = false, 
+        bool isUnsafe = false, 
+        size_t line = 0, size_t column = 0);
     
     // Delete copy constructor and assignment operator
     FunctionDecl(const FunctionDecl&) = delete;

--- a/include/ast/dumper.h
+++ b/include/ast/dumper.h
@@ -27,27 +27,40 @@ public:
     virtual ~ASTDumper() = default;
 
     /// Dump an AST node to stdout with colored output
-    void dump(const ASTNode& node);
-
+    void dump(const ASTNode& node);    
+    
     // Visitor interface implementation - matches visitor.h exactly
     void visit(Program& node) override;
     
+    // Expression visitors
     void visit(LiteralExpr& node) override;
     void visit(IdentifierExpr& node) override;
     void visit(BinaryOpExpr& node) override;
     void visit(UnaryOpExpr& node) override;
     void visit(AssignmentExpr& node) override;
     void visit(FunctionCallExpr& node) override;
+    void visit(MemberExpr& node) override;
+#ifdef EMLANG_FEATURE_CASTING
+    void visit(CastExpr& node) override;
+#endif // EMLANG_FEATURE_CASTING
+    void visit(IndexExpr& node) override;
+    void visit(ArrayExpr& node) override;
+    void visit(ObjectExpr& node) override;
+#ifdef EMLANG_FEATURE_POINTERS
     void visit(DereferenceExpr& node) override;
     void visit(AddressOfExpr& node) override;
+#endif
 
+    // Declaration visitors
     void visit(VariableDecl& node) override;
     void visit(FunctionDecl& node) override;
     void visit(ExternFunctionDecl& node) override;
     
+    // Statement visitors
     void visit(BlockStmt& node) override;
     void visit(IfStmt& node) override;
     void visit(WhileStmt& node) override;
+    void visit(ForStmt& node) override;
     void visit(ReturnStmt& node) override;
     void visit(ExpressionStmt& node) override;
 

--- a/include/ast/expr.h
+++ b/include/ast/expr.h
@@ -52,19 +52,17 @@ public:
  */
 class EMLANG_API BinaryOpExpr : public Expression {
 public:
-    ExpressionPtr left;         // Left operand
-    std::string operator_;      // Operator symbol
-    ExpressionPtr right;        // Right operand
+    enum class BinOp {
+        ADD, SUB, MUL, DIV, MOD,
+        AND, OR, XOR, INV, SHL, SHR,
+        EQ, NE, LT, LE, GT, GE,
+        LAND, LOR, LNOT,
+    };
+    ExpressionPtr left;     // Left operand
+    BinOp operator_;        // Operator symbol
+    ExpressionPtr right;    // Right operand
     
-    BinaryOpExpr(ExpressionPtr left, const std::string& op, ExpressionPtr right, size_t line = 0, size_t column = 0);
-    
-    // Delete copy constructor and assignment operator
-    BinaryOpExpr(const BinaryOpExpr&) = delete;
-    BinaryOpExpr& operator=(const BinaryOpExpr&) = delete;
-    
-    // Enable move constructor and assignment operator
-    BinaryOpExpr(BinaryOpExpr&&) = default;
-    BinaryOpExpr& operator=(BinaryOpExpr&&) = default;
+    BinaryOpExpr(ExpressionPtr left, const BinOp& op, ExpressionPtr right, size_t line = 0, size_t column = 0);
     
     std::string toString() const override;
     void accept(ASTVisitor& visitor) override;
@@ -76,18 +74,10 @@ public:
  */
 class EMLANG_API UnaryOpExpr : public Expression {
 public:
-    std::string operator_;      // Operator symbol
-    ExpressionPtr operand;      // Operand expression
+    BinaryOpExpr::BinOp operator_;  // Operator symbol
+    ExpressionPtr operand;          // Operand expression
     
-    UnaryOpExpr(const std::string& op, ExpressionPtr operand, size_t line = 0, size_t column = 0);
-    
-    // Delete copy constructor and assignment operator
-    UnaryOpExpr(const UnaryOpExpr&) = delete;
-    UnaryOpExpr& operator=(const UnaryOpExpr&) = delete;
-    
-    // Enable move constructor and assignment operator
-    UnaryOpExpr(UnaryOpExpr&&) = default;
-    UnaryOpExpr& operator=(UnaryOpExpr&&) = default;
+    UnaryOpExpr(const BinaryOpExpr::BinOp& op, ExpressionPtr operand, size_t line = 0, size_t column = 0);
     
     std::string toString() const override;
     void accept(ASTVisitor& visitor) override;
@@ -104,14 +94,6 @@ public:
     
     AssignmentExpr(ExpressionPtr target, ExpressionPtr value, size_t line = 0, size_t column = 0);
     
-    // Delete copy constructor and assignment operator
-    AssignmentExpr(const AssignmentExpr&) = delete;
-    AssignmentExpr& operator=(const AssignmentExpr&) = delete;
-    
-    // Enable move constructor and assignment operator
-    AssignmentExpr(AssignmentExpr&&) = default;
-    AssignmentExpr& operator=(AssignmentExpr&&) = default;
-    
     std::string toString() const override;
     void accept(ASTVisitor& visitor) override;
 };
@@ -119,11 +101,14 @@ public:
 /**
  * @class FunctionCallExpression
  * @brief Represents function call expressions
+ * IMPLEMENT: FunctionCallExpr -> CallExpr
  */
 class EMLANG_API FunctionCallExpr : public Expression {
 public:
+    //ExpressionPtr callee;                 // The function being called
     std::string functionName;               // Name of the function being called
     std::vector<ExpressionPtr> arguments;   // Function arguments
+    //std::vector<> generic_args;           // Generic arguments (if any)
     
     FunctionCallExpr(const std::string& name, std::vector<ExpressionPtr> args, size_t line = 0, size_t column = 0);
     
@@ -311,6 +296,35 @@ public:
 };
 #endif // EMLANG_FEATURE_POINTERS
 
+/****************************************
+* Helper functions for expression creation
+****************************************/
+/* BinOp to string method */
+std::string binOpToString(BinaryOpExpr::BinOp op) {
+    switch (op) {
+        case BinaryOpExpr::BinOp::ADD: return "+";
+        case BinaryOpExpr::BinOp::SUB: return "-";
+        case BinaryOpExpr::BinOp::MUL: return "*";
+        case BinaryOpExpr::BinOp::DIV: return "/";
+        case BinaryOpExpr::BinOp::MOD: return "%";
+        case BinaryOpExpr::BinOp::AND: return "&";
+        case BinaryOpExpr::BinOp::OR: return "|";
+        case BinaryOpExpr::BinOp::XOR: return "^";
+        case BinaryOpExpr::BinOp::INV: return "~";
+        case BinaryOpExpr::BinOp::SHL: return "<<";
+        case BinaryOpExpr::BinOp::SHR: return ">>";
+        case BinaryOpExpr::BinOp::EQ: return "==";
+        case BinaryOpExpr::BinOp::NE: return "!=";
+        case BinaryOpExpr::BinOp::LT: return "<";
+        case BinaryOpExpr::BinOp::LE: return "<=";
+        case BinaryOpExpr::BinOp::GT: return ">";
+        case BinaryOpExpr::BinOp::GE: return ">=";
+        case BinaryOpExpr::BinOp::LAND: return "&&";
+        case BinaryOpExpr::BinOp::LOR: return "||";
+        case BinaryOpExpr::BinOp::LNOT: return "!";
+    }
+    return "";
+}
 
 } // namespace emlang
 

--- a/include/ast/expr.h
+++ b/include/ast/expr.h
@@ -140,6 +140,131 @@ public:
 };
 
 /**
+ * @class MemberExpression
+ * @brief Represents member access operations (obj.member)
+ */
+class EMLANG_API MemberExpr : public Expression {
+public:
+    ExpressionPtr object;       // Object being accessed
+    std::string memberName;     // Name of the member
+    bool isMethodCall;          // true if this is a method call
+    
+    MemberExpr(
+        ExpressionPtr object, 
+        const std::string& memberName, 
+        bool isMethodCall = false, 
+        size_t line = 0, size_t column = 0);
+    
+    std::string toString() const override;
+    void accept(ASTVisitor& visitor) override;
+};
+
+/**
+ * @class CastExpression
+ * @brief Represents type casting operations (expr as Type or cast<Type>(expr))
+ */
+#ifdef EMLANG_FEATURE_CASTING
+class EMLANG_API CastExpr : public Expression {
+public:
+    ExpressionPtr operand;      // Expression being cast
+    std::string targetType;     // Target type name
+    bool isExplicit;            // true for explicit cast, false for implicit
+    
+    CastExpr(ExpressionPtr operand, const std::string& targetType, bool isExplicit = true, size_t line = 0, size_t column = 0);
+    
+    // Delete copy constructor and assignment operator
+    CastExpr(const CastExpr&) = delete;
+    CastExpr& operator=(const CastExpr&) = delete;
+    
+    // Enable move constructor and assignment operator
+    CastExpr(CastExpr&&) = default;
+    CastExpr& operator=(CastExpr&&) = default;
+    
+    std::string toString() const override;
+    void accept(ASTVisitor& visitor) override;
+};
+#endif // EMLANG_FEATURE_CASTING
+
+/**
+ * @class IndexExpression
+ * @brief Represents array indexing operations (arr[index])
+ */
+class EMLANG_API IndexExpr : public Expression {
+public:
+    ExpressionPtr array;        // Array expression
+    ExpressionPtr index;        // Index expression
+    
+    IndexExpr(ExpressionPtr array, ExpressionPtr index, size_t line = 0, size_t column = 0);
+
+    std::string toString() const override;
+    void accept(ASTVisitor& visitor) override;
+};
+
+/**
+ * @class ArrayExpression
+ * @brief Represents array literals ([1, 2, 3])
+ */
+class EMLANG_API ArrayExpr : public Expression {
+public:
+    std::vector<ExpressionPtr> elements;    // Array elements
+    
+    ArrayExpr(std::vector<ExpressionPtr> elements, size_t line = 0, size_t column = 0);
+    
+    // Delete copy constructor and assignment operator
+    ArrayExpr(const ArrayExpr&) = delete;
+    ArrayExpr& operator=(const ArrayExpr&) = delete;
+    
+    // Enable move constructor and assignment operator
+    ArrayExpr(ArrayExpr&&) = default;
+    ArrayExpr& operator=(ArrayExpr&&) = default;
+    
+    std::string toString() const override;
+    void accept(ASTVisitor& visitor) override;
+};
+
+/**
+ * @struct ObjectField
+ * @brief Represents a field in an object literal
+ */
+struct ObjectField {
+    std::string key;            // Field key
+    ExpressionPtr value;        // Field value
+    
+    ObjectField(const std::string& key, ExpressionPtr value) : key(key), value(std::move(value)) {}
+    
+    // Delete copy constructor and assignment operator
+    ObjectField(const ObjectField&) = delete;
+    ObjectField& operator=(const ObjectField&) = delete;
+    
+    // Enable move constructor and assignment operator
+    ObjectField(ObjectField&&) = default;
+    ObjectField& operator=(ObjectField&&) = default;
+};
+
+/**
+ * @class ObjectExpression
+ * @brief Represents object literals ({key: value})
+ */
+class EMLANG_API ObjectExpr : public Expression {
+public:
+    std::vector<ObjectField> fields;    // Object fields
+    
+    ObjectExpr(std::vector<ObjectField> fields, size_t line = 0, size_t column = 0);
+    
+    // Delete copy constructor and assignment operator
+    ObjectExpr(const ObjectExpr&) = delete;
+    ObjectExpr& operator=(const ObjectExpr&) = delete;
+    
+    // Enable move constructor and assignment operator
+    ObjectExpr(ObjectExpr&&) = default;
+    ObjectExpr& operator=(ObjectExpr&&) = default;
+    
+    std::string toString() const override;
+    void accept(ASTVisitor& visitor) override;
+};
+
+#ifdef EMLANG_FEATURE_POINTERS
+/**
  * @class DereferenceExpression
  * @brief Represents pointer dereference operations (*ptr)
  */
@@ -164,6 +289,8 @@ public:
 /**
  * @class AddressOfExpression
  * @brief Represents address-of operations (&var)
+ * 
+ * IMPORTANT: Experimental Feature
  */
 class EMLANG_API AddressOfExpr : public Expression {
 public:
@@ -182,6 +309,8 @@ public:
     std::string toString() const override;
     void accept(ASTVisitor& visitor) override;
 };
+#endif // EMLANG_FEATURE_POINTERS
+
 
 } // namespace emlang
 

--- a/include/ast/stmt.h
+++ b/include/ast/stmt.h
@@ -87,6 +87,31 @@ public:
 };
 
 /**
+ * @class ForStatement
+ * @brief Represents for loop statements
+ */
+class EMLANG_API ForStmt : public Statement {
+public:
+    StatementPtr initializer;   // Loop initialization (optional)
+    ExpressionPtr condition;    // Loop condition (optional)
+    ExpressionPtr increment;    // Loop increment (optional)
+    StatementPtr body;          // Loop body
+    
+    ForStmt(StatementPtr init, ExpressionPtr cond, ExpressionPtr incr, StatementPtr body, size_t line = 0, size_t column = 0);
+    
+    // Delete copy constructor and assignment operator
+    ForStmt(const ForStmt&) = delete;
+    ForStmt& operator=(const ForStmt&) = delete;
+    
+    // Enable move constructor and assignment operator
+    ForStmt(ForStmt&&) = default;
+    ForStmt& operator=(ForStmt&&) = default;
+    
+    std::string toString() const override;
+    void accept(ASTVisitor& visitor) override;
+};
+
+/**
  * @class ReturnStatement
  * @brief Represents return statements
  */

--- a/include/ast/visitor.h
+++ b/include/ast/visitor.h
@@ -26,12 +26,18 @@ class AssignmentExpr;
 class FunctionCallExpr;
 class DereferenceExpr;
 class AddressOfExpr;
+class MemberExpr;
+class CastExpr;
+class IndexExpr;
+class ArrayExpr;
+class ObjectExpr;
 class VariableDecl;
 class FunctionDecl;
 class ExternFunctionDecl;
 class BlockStmt;
 class IfStmt;
 class WhileStmt;
+class ForStmt;
 class ReturnStmt;
 class ExpressionStmt;
 
@@ -51,22 +57,35 @@ public:
     // Visit methods for all AST node types
     virtual void visit(Program& node) = 0;
 
+    // Expression visitors
     virtual void visit(LiteralExpr& node) = 0;
     virtual void visit(IdentifierExpr& node) = 0;
     virtual void visit(BinaryOpExpr& node) = 0;
     virtual void visit(UnaryOpExpr& node) = 0;
     virtual void visit(AssignmentExpr& node) = 0;
     virtual void visit(FunctionCallExpr& node) = 0;
+    virtual void visit(MemberExpr& node) = 0;
+#ifdef EMLANG_FEATURE_CASTING
+    virtual void visit(CastExpr& node) = 0;
+#endif
+    virtual void visit(IndexExpr& node) = 0;
+    virtual void visit(ArrayExpr& node) = 0;
+    virtual void visit(ObjectExpr& node) = 0;
+#ifdef EMLANG_FEATURE_POINTERS
     virtual void visit(DereferenceExpr& node) = 0;
     virtual void visit(AddressOfExpr& node) = 0;
+#endif
 
+    // Declaration visitors
     virtual void visit(VariableDecl& node) = 0;
     virtual void visit(FunctionDecl& node) = 0;
     virtual void visit(ExternFunctionDecl& node) = 0;
     
+    // Statement visitors
     virtual void visit(BlockStmt& node) = 0;
     virtual void visit(IfStmt& node) = 0;
     virtual void visit(WhileStmt& node) = 0;
+    virtual void visit(ForStmt& node) = 0;
     virtual void visit(ReturnStmt& node) = 0;
     virtual void visit(ExpressionStmt& node) = 0;
 };

--- a/include/emlang.h
+++ b/include/emlang.h
@@ -29,10 +29,10 @@
 /***************************************
 *  Feature flags
 ***************************************/
-#define EMLANG_FEATURE_EXTERN_FUNCTIONS  0
 #define EMLANG_FEATURE_POINTERS          0
-#define EMLANG_FEATURE_STRINGS           0
-#define EMLANG_FEATURE_ARRAYS            0
+#define EMLANG_FEATURE_CASTING           0
+#define EMLANG_FEATURE_IMPORTS           0
+#define EMLANG_FEATURE_EXTERN_FUNCTIONS  0
 
 
 #endif // EMLANG_H


### PR DESCRIPTION
## About this pull request
This pull request introduces significant updates to the `emlang` language documentation and compiler codebase. The documentation now provides a more structured and tabular format for language features, while the compiler codebase has undergone a major refactoring to improve type handling, introduce new node types, and enhance the AST dumping functionality.

### Documentation Updates:
* [`emlang/README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L55-L140): Replaced code examples with structured tables for primitive types, Unicode/string support, pointer system, function declarations, and control flow constructs to improve readability and accessibility.

### AST Refactoring:
#### Type System Improvements:
* [`compiler/ast/ast_base.cpp`](diffhunk://#diff-4feefb1ff83ed70aa08b07bb2085a7114eb4e16d5f82faaf53ee0499b9d0395cL10-R30): Refactored `ASTNode` to use `NodeType` instead of `ASTNodeType`, and added base classes for `Expression` and `Statement` to clarify hierarchy.
* [`compiler/ast/decl.cpp`](diffhunk://#diff-f245ffc7a77d56b78e3b0c7b1764b6742e81b219501c807fc1b216b012263332L25-R34): Updated `VariableDecl`, `FunctionDecl`, and `ExternFunctionDecl` constructors to use `NodeType` and added support for optional types and new properties like `isExtern`, `isAsync`, and `isUnsafe`. [[1]](diffhunk://#diff-f245ffc7a77d56b78e3b0c7b1764b6742e81b219501c807fc1b216b012263332L25-R34) [[2]](diffhunk://#diff-f245ffc7a77d56b78e3b0c7b1764b6742e81b219501c807fc1b216b012263332R52-R64) [[3]](diffhunk://#diff-f245ffc7a77d56b78e3b0c7b1764b6742e81b219501c807fc1b216b012263332L86-R92)

#### Expression Enhancements:
* [`compiler/ast/expr.cpp`](diffhunk://#diff-f4bcff59b66e054033a371125fee0976f38eb6d4be9192ecdf10079d23320ea6L17-R28): Refactored expression classes to use `NodeType` and replaced string-based operators with `BinOp` enum for binary and unary expressions. Added helper function `binOpToString` for operator representation. [[1]](diffhunk://#diff-f4bcff59b66e054033a371125fee0976f38eb6d4be9192ecdf10079d23320ea6L17-R28) [[2]](diffhunk://#diff-f4bcff59b66e054033a371125fee0976f38eb6d4be9192ecdf10079d23320ea6L54-R67)

#### AST Dumping Improvements:
* [`compiler/ast/dumper.cpp`](diffhunk://#diff-8065f32abae8d7810ab7d7124dd4eba1e842265d9ffe7347e80062ea8a2f2e03L95-R95): Enhanced the `ASTDumper` with new visitors for `MemberExpr`, `CastExpr`, `IndexExpr`, `ArrayExpr`, and `ObjectExpr`. Improved handling of optional types and added support for new node types and features like explicit casting and pointer expressions. [[1]](diffhunk://#diff-8065f32abae8d7810ab7d7124dd4eba1e842265d9ffe7347e80062ea8a2f2e03L95-R95) [[2]](diffhunk://#diff-8065f32abae8d7810ab7d7124dd4eba1e842265d9ffe7347e80062ea8a2f2e03R155-R237) [[3]](diffhunk://#diff-8065f32abae8d7810ab7d7124dd4eba1e842265d9ffe7347e80062ea8a2f2e03R317-R342)

These changes collectively improve the clarity, extensibility, and functionality of the `emlang` language and its compiler.