### PR TITLE
Parser refactoring and improvments 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 /tests/*.dll
 /tests/*.exe
 /tests/*.pdb
+
+# Vscode
+.vscode/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Clang compiler selection (cmake .. -DUSE_CLANG=ON)
-option(USE_CLANG "Use Clang compiler instead of default" OFF)
+cmake_minimum_required(VERSION 3.20)
+project(EMLang VERSION 1.0.0 LANGUAGES CXX)
 
-# Library build selection (cmake .. -DBUILD_LIBRARY=ON)
-option(BUILD_LIBRARY "Build EMLang standard library" ON)
+option(USE_CLANG "Use Clang compiler instead of default" OFF)
+option(BUILD_LIBRARY "Build EMLang standard library" OFF)
 
 # Compiler selection (must be before project() call)
 if(USE_CLANG)
@@ -35,44 +35,20 @@ if(USE_CLANG)
     endif()
 endif()
 
-cmake_minimum_required(VERSION 3.20)
-project(EMLang VERSION 1.0.0 LANGUAGES CXX)
-
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# Special compiler flags for Clang
-if(USE_CLANG)
-    message(STATUS "C Compiler: ${CMAKE_C_COMPILER}")
-    message(STATUS "CXX Compiler: ${CMAKE_CXX_COMPILER}")
-    
-    # General compiler flags for Clang
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-command-line-argument")
-    
-    # For MSVC compatibility on Windows
-    if(WIN32)
-        # Use MSVC C++ standard library, in MSVC compatible mode
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-compatibility-version=19.29")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fms-extensions")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdelayed-template-parsing")
-        # Use Visual Studio C runtime
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS")
-    endif()
-    
-    # Better error messages in debug mode
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics -fansi-escape-codes")
-    endif()
-endif()
 
 # For Windows DLL export/import symbols
 if(WIN32)
     add_definitions(-DWIN32_LEAN_AND_MEAN)
+    # Enable global symbol export for DLL
     set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+    # Set the DLL API calling convention
+    set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 endif()
 
-# LLVM configuration (optional for now)
-find_package(LLVM CONFIG)
+# LLVM configuration
+find_package(LLVM REQUIRED CONFIG)
 
 if(LLVM_FOUND)
     message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
@@ -82,18 +58,23 @@ if(LLVM_FOUND)
     separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
     add_definitions(${LLVM_DEFINITIONS_LIST})
     
+    # Map LLVM components to libraries - simplified for compatibility
     llvm_map_components_to_libnames(llvm_libs 
         support core analysis target
-        native nativecodegen
-        mcjit executionengine
+        native codegen
+        
+        # Target architectures - needed for InitializeAll*Target* functions
+        AArch64 ARM BPF WebAssembly RISCV NVPTX X86
+
+        mcjit executionengine runtimedyld
+        
         transformutils scalaropts instcombine ipo
-        mc asmprinter
+        mc asmprinter asmparser
     )
     set(LLVM_LIBRARIES ${llvm_libs})
     set(LLVM_ENABLED TRUE)
 else()
-    message(STATUS "LLVM not found - building without LLVM support")
-    set(LLVM_LIBRARIES "")
+    message(FATAL_ERROR "LLVM not found! Please install LLVM or set LLVM_DIR to the correct path")
     set(LLVM_ENABLED FALSE)
 endif()
 
@@ -102,16 +83,6 @@ include_directories(include)
 
 # Compiler components (as DLL)
 add_subdirectory(compiler)
-
-# EMLang standard library (optional - as static library)
-if(BUILD_LIBRARY)
-    message(STATUS "Building EMLang standard library")
-    add_subdirectory(library)
-    set(LIBRARY_TARGET emlang_lib)
-else()
-    message(STATUS "Skipping EMLang standard library build")
-    set(LIBRARY_TARGET "")
-endif()
 
 # ===========================
 # EMLang Executables
@@ -125,27 +96,25 @@ add_executable(emlang_check src/emlang_check.cpp)
 
 # ===========================
 
-# Include directories (conditional)
-if(BUILD_LIBRARY)
-    target_include_directories(emlang PRIVATE library/include)
-    target_include_directories(emlang_check PRIVATE library/include)
-endif()
-
 # Compiler DLL linkage for emlang_check
-target_link_libraries(emlang_check emlang_compiler)
+target_link_libraries(emlang PRIVATE emlang_compiler)
+target_link_libraries(emlang_check PRIVATE emlang_compiler)
+
+# Define EMLANG_DLL for importing symbols from emlang_compiler.dll
+target_compile_definitions(emlang PRIVATE EMLANG_DLL)
+target_compile_definitions(emlang_check PRIVATE EMLANG_DLL)
 
 # Linkage - compiler DLL always, library conditional
 if(BUILD_LIBRARY)
-    target_link_libraries(emlang emlang_compiler ${LIBRARY_TARGET})
-else()
-    target_link_libraries(emlang emlang_compiler)
-endif()
+    message(STATUS "Building EMLang standard library")
+    add_subdirectory(library)
 
-# Disable MSVC linker warnings
-if(MSVC)
-    set_target_properties(emlang PROPERTIES
-        LINK_FLAGS "/ignore:4197 /ignore:4199"
-    )
+    target_include_directories(emlang PRIVATE library/include)
+    target_include_directories(emlang_check PRIVATE library/include)
+    target_link_libraries(emlang PRIVATE emlang_lib)
+    target_link_libraries(emlang_check PRIVATE emlang_lib)
+else()
+    message(STATUS "Skipping EMLang standard library build")
 endif()
 
 # Copy DLL next to executable
@@ -163,3 +132,10 @@ add_custom_command(TARGET emlang_check POST_BUILD
     $<TARGET_FILE_DIR:emlang_check>
     COMMENT "Copying emlang_compiler.dll to emlang_check directory"
 )
+
+# Disable MSVC linker warnings
+if(MSVC)
+    set_target_properties(emlang PROPERTIES
+        LINK_FLAGS "/ignore:4197 /ignore:4199"
+    )
+endif()

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 EMLang Project
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![LLVM](https://img.shields.io/badge/LLVM-17+-blue.svg)](https://llvm.org/)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![C++](https://img.shields.io/badge/C%2B%2B-17-blue.svg)](#prerequisites)
-[![v0.9.26](https://img.shields.io/badge/EMLang_Version-0.9.26-purple.svg)](version)
+[![v1.0.0](https://img.shields.io/badge/EMLang_Version-1.0.0.alpha.3-purple.svg)](version)
 
 EMLang is a statically-typed systems programming language designed for high-performance applications with ahead-of-time (AOT) compilation using LLVM. It combines modern language features with C-like performance and memory control.
 
@@ -52,92 +52,64 @@ emlang/
 
 ## ✨ Language Features
 
-#### ✅ **Primitive Types**
-```emlang
-// Integer types with explicit sizing
-let byte: int8 = 127;
-let short: int16 = 32767;
-let normal: int32 = 2147483647;
-let large: int64 = 9223372036854775807;
+### **Primitive Types**
 
-// Unsigned variants
-let ubyte: uint8 = 255;
-let ushort: uint16 = 65535;
-let uint: uint32 = 4294967295;
-let ulong: uint64 = 18446744073709551615;
+| Type     | Size   | Description      | Min Value | Max Value |
+|----------|--------|------------------|-----------|-----------|
+| `int8`   | 8-bit  | Signed integer   | -128 | 127 |
+| `int16`  | 16-bit | Signed integer   | -32,768 | 32,767 |
+| `int32`  | 32-bit | Signed integer   | -2,147,483,648 | 2,147,483,647 |
+| `int64`  | 64-bit | Signed integer   | -9,223,372,036,854,775,808 | 9,223,372,036,854,775,807 |
+| `uint8`  | 8-bit  | Unsigned integer | 0 | 255 |
+| `uint16` | 16-bit | Unsigned integer | 0 | 65,535 |
+| `uint32` | 32-bit | Unsigned integer | 0 | 4,294,967,295 |
+| `uint64` | 64-bit | Unsigned integer | 0 | 18,446,744,073,709,551,615 |
+| `float`  | 32-bit | Floating point   | ~-3.4e38 | ~3.4e38 |
+| `double` | 64-bit | Double precision | ~-1.8e308 | ~1.8e308 |
+| `bool`   | 1-bit  | Boolean          | `false` | `true` |
+| `char`   | 8-bit  | Character        | 0 | 255 |
 
-// Floating point precision
-let precision: float = 3.14159;
-let highPrecision: double = 2.718281828459045;
+### **Unicode and String Support**
 
-// Boolean and character types
-let flag: bool = true;
-let character: char = 'A';
-```
+| Feature                | Description | Examples |
+|------------------------|-------------|----------|
+| **Unicode Characters** | Full UTF-8 character support | `'😀'`, `'π'`, `'€'` |
+| **Escape Sequences**   | Standard C-style escapes | `'\n'`, `'\t'`, `'\\'`, `'\"'` |
+| **Unicode Escapes**    | Unicode code point notation | `'\u{03C0}'` (π), `'\u{20AC}'` (€) |
+| **String Literals**    | UTF-8 string support | `"Hello, World!"` |
+| **Path Strings**       | Windows/Unix path support | `"C:\\Users\\Name"` |
+| **Mixed Content**      | Unicode in strings | `"Càf Manü ★ ♠ ♥"` |
 
-#### ✅ **Unicode and String Support**
-```emlang
-// Unicode character literals
-let emoji: char = '😀';
-let greek: char = '\u{03C0}';  // π
-let euro: char = '\u{20AC}';   // €
+### **C-Style Pointer System**
 
-// String literals with escape sequences
-let message: str = "Hello, World!\n";
-let path: str = "C:\\Users\\Name\\Documents";
-let unicode: str = "Café Münü with symbols: ★ ♠ ♥";
-```
+| Feature | Operator | Description | Usage |
+|---------|----------|-------------|-------|
+| **Address-of** | `&` | Gets memory address | `&variable` |
+| **Dereference** | `*` | Accesses value at address | `*pointer` |
+| **Pointer Declaration** | `*` | Declares pointer type | `int32*` |
+| **Multi-level Pointers** | `**` | Pointer to pointer | `int32**` |
+| **Null Pointer** | `null` | Null pointer value | `ptr = null` |
 
-#### ✅ **C-Style Pointer System**
-```emlang
-function pointerDemo(): int32 {
-    let value: int32 = 42;
-    let ptr: int32* = &value;        // Address-of operator
-    let deref: int32 = *ptr;         // Dereference operator
-    
-    // Multi-level pointers
-    let ptrToPtr: int32** = &ptr;
-    let final: int32 = **ptrToPtr;
-    
-    return final;
-}
-```
+### **Function Declarations**
 
-#### ✅ **Function Declarations**
-```emlang
-function fibonacci(n: int32): int32 {
-    if (n <= 1) {
-        return n;
-    }
-    return fibonacci(n-1) + fibonacci(n-2);
-}
+| Feature | Syntax | Description | Example |
+|---------|--------|-------------|---------|
+| **Function Definition** | `function name(): type` | Regular function | `function add(a: int32, b: int32): int32` |
+| **External Functions** | `extern function` | External C functions | `extern function printf(format: str): int32` |
+| **Void Functions** | `: void` | No return value | `function print(): void` |
+| **Parameters** | `name: type` | Typed parameters | `(x: int32, y: float)` |
+| **Return Statement** | `return value` | Function return | `return x + y` |
 
-// External function declarations
-extern function printf(format: str): int32;
-```
+### **Control Flow**
 
-#### ✅ **Control Flow**
-```emlang
-function controlFlow(): void {
-    let x: int32 = 10;
-    
-    // Conditional statements
-    if (x > 5) {
-        // True branch
-    } else {
-        // False branch
-    }
-    
-    // Loop constructs
-    while (x > 0) {
-        x = x - 1;
-    }
-    
-    for (let i: int32 = 0; i < 10; i = i + 1) {
-        // Loop body
-    }
-}
-```
+| Structure | Syntax | Description | Features |
+|-----------|--------|-------------|----------|
+| **If Statement** | `if (condition) { }` | Conditional execution | With optional `else` |
+| **While Loop** | `while (condition) { }` | Pre-condition loop | Condition checked first |
+| **For Loop** | `for (init; condition; update)` | Counting loop | C-style syntax |
+| **Block Scope** | `{ ... }` | Code blocks | Local variable scope |
+| **Nested Structures** | - | All structures nestable | Unlimited nesting depth |
+
 
 ## 🏗️ Architecture & Implementation
 
@@ -166,6 +138,8 @@ function controlFlow(): void {
 - **Optimization passes** integration
 
 ### 📚 **Standard Library**
+> [!Warning]
+> The emlang standard library is not available at the moment. It will be available in beta.
 The library provides essential functionality across multiple domains:
 
 - **I/O Operations**: `emlang_print_*`, `emlang_read_*`, console control
@@ -178,7 +152,7 @@ The library provides essential functionality across multiple domains:
 
 ### Prerequisites
 - **CMake** 3.10 or higher
-- **C++17** compatible compiler (GCC 7+, Clang 5+, MSVC 2017+)
+- **C++17** compatible compiler (GCC 9+, Clang 8+, MSVC 2017+)
 - **LLVM** 14+ (automatically detected, enables code generation)
 - **Git** for cloning and version control
 
@@ -370,93 +344,6 @@ done
 ./build/Debug/emlang_check --all tests/phase3_pointer_test.em
 ```
 
-## 📈 Development Roadmap
-
-### ✅ **Completed Phases**
-
-#### **Phase 1**: Core Type System
-- [x] Primitive integer types (int8, int16, int32, int64)
-- [x] Unsigned variants (uint8, uint16, uint32, uint64)
-- [x] Floating point types (float, double)
-- [x] Boolean and void types
-- [x] LLVM backend integration
-
-#### **Phase 2**: Character & String System  
-- [x] Unicode character support (`char` type)
-- [x] String literals with escape sequences
-- [x] Character literals with Unicode escapes
-- [x] UTF-8 string handling
-- [x] Comprehensive string operations
-
-#### **Phase 3**: C-Style Pointer System
-- [x] Pointer type declarations (`int32*`, `char**`)
-- [x] Address-of operator (`&variable`)
-- [x] Dereference operator (`*pointer`)
-- [x] Multi-level pointer support
-- [x] Pointer arithmetic and type safety
-- [x] Complete semantic analysis
-
-### 🚧 **In Progress**
-
-#### **Phase 4**: Advanced Features
-- [ ] Array types and operations
-- [ ] Struct/record types
-- [ ] Enum types
-- [ ] Pattern matching
-
-### 🔮 **Future Plans**
-
-#### **Phase 5**: Advanced Language Features
-- [ ] Generic types and functions
-- [ ] Module system with imports
-- [ ] Memory ownership model
-- [ ] Async/await support
-
-#### **Phase 6**: Development Tools
-- [ ] Language Server Protocol (LSP)
-- [ ] IDE integration and plugins
-- [ ] Package manager
-- [ ] Documentation generator
-
-## 📚 Library Reference
-
-### Standard Library Modules
-
-#### 🔢 **Mathematics** (`math.h`)
-```c
-float emlang_pow(float base, float exp);     // Power function
-float emlang_sqrt(float x);                  // Square root
-float emlang_sin(float x);                   // Sine function
-float emlang_cos(float x);                   // Cosine function
-float emlang_tan(float x);                   // Tangent function
-float emlang_abs(float x);                   // Absolute value
-```
-
-#### 📝 **String Operations** (`string.h`)
-```c
-int emlang_strlen(const char* str);                    // String length
-int emlang_strcmp(const char* str1, const char* str2); // String comparison  
-char* emlang_strcpy(char* dest, const char* src);      // String copy
-char* emlang_to_upper(char* str);                      // Convert to uppercase
-char* emlang_to_lower(char* str);                      // Convert to lowercase
-```
-
-#### 💾 **Memory Management** (`memory.h`)
-```c
-void* emlang_malloc(int size);              // Allocate memory
-void emlang_free(void* ptr);                // Free allocated memory
-void emlang_memset(void* ptr, int val, int size); // Set memory values
-```
-
-#### 🖥️ **Input/Output** (`io.h`)
-```c
-void emlang_print_int(int value);           // Print integer
-void emlang_print_str(const char* str);     // Print string
-void emlang_print_char(char c);             // Print character
-int emlang_read_int(void);                  // Read integer from input
-char emlang_read_char(void);                // Read character from input
-```
-
 ## 🤝 Contributing
 
 We welcome contributions to EMLang! Here's how you can help:
@@ -492,41 +379,14 @@ We welcome contributions to EMLang! Here's how you can help:
 - **Testing**: Additional test cases and edge cases
 
 ## 📄 License
-
 EMLang is released under the **MIT License**. See [LICENSE](LICENSE) file for details.
-
-```
-MIT License
-
-Copyright (c) 2025 EMLang Project
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-```
 
 ---
 
 ## 🔗 Links & Resources
 
-- **📖 Documentation**: [EMLang Language Guide](docs/)
 - **🐛 Issue Tracker**: [GitHub Issues](https://github.com/ByaCherX/emlang/issues)
 - **💬 Discussions**: [GitHub Discussions](https://github.com/ByaCherX/emlang/discussions)
-- **📧 Contact**: [project@emlang.dev](mailto:project@emlang.dev)
 
 ---
 

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -1,17 +1,19 @@
+# Add subdirectories for each component as OBJECT libraries
 add_subdirectory(lexer)
 add_subdirectory(ast)
 add_subdirectory(parser)
 add_subdirectory(semantic)
 add_subdirectory(codegen)
 
+# EMLang Compiler DLL - uses OBJECT libraries for direct symbol embedding
 add_library(emlang_compiler SHARED
-    lexer/lexer.cpp
-    ast/ast.cpp
-    parser/parser.cpp
-    semantic/semantic.cpp
-    codegen/codegen.cpp
+    # Built-ins and main compiler interface
     builtins.cpp
-
+    
+    # Resource file
+    emlang_compiler.rc
+    
+    # Include all object files from the OBJECT libraries
     $<TARGET_OBJECTS:emlang_lexer>
     $<TARGET_OBJECTS:emlang_ast>
     $<TARGET_OBJECTS:emlang_parser>
@@ -28,57 +30,32 @@ target_include_directories(emlang_compiler PUBLIC
     ${CMAKE_SOURCE_DIR}/include/codegen
 )
 
+# Link with OBJECT libraries (inheritance of include directories)
+target_link_libraries(emlang_compiler 
+    # No need to link the object libraries, they're already embedded
+)
+
 # DLL export definitions
 target_compile_definitions(emlang_compiler PRIVATE EMLANG_EXPORTS)
 target_compile_definitions(emlang_compiler PUBLIC EMLANG_DLL)
 
-# MSVC warning'lerini ve linker uyarılarını kapat
+# Compiler settings
 if(MSVC)
     target_compile_options(emlang_compiler PRIVATE
         /wd4624  # destructor was implicitly deleted
         /wd4244  # conversion warnings
         /wd4267  # size_t conversion warnings
-    )
-    
-    # Linker uyarılarını kapat
-    set_target_properties(emlang_compiler PROPERTIES
-        LINK_FLAGS "/ignore:4197 /ignore:4199"
+        /wd4251  # DLL interface warning for STL containers
     )
 endif()
 
-# Clang için özel ayarlar
-if(USE_CLANG)
-    target_compile_options(emlang_compiler PRIVATE
-        -Wno-unused-command-line-argument
-        -Wno-deprecated-declarations
-    )
-    
-    # Windows'ta MSVC uyumluluğu
-    if(WIN32)
-        target_compile_options(emlang_compiler PRIVATE
-            -fms-compatibility-version=19.29
-            -fms-extensions
-            -fdelayed-template-parsing
-        )
-        target_compile_definitions(emlang_compiler PRIVATE
-            _CRT_SECURE_NO_WARNINGS
-        )
-    endif()
-    
-    # Debug modunda ekstra bilgi
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        target_compile_options(emlang_compiler PRIVATE
-            -fcolor-diagnostics
-            -fansi-escape-codes
-        )
-    endif()
-endif()
-
-# LLVM bağlantısı varsa ekle
-if(LLVM_FOUND)
+# Add LLVM support if available
+if(LLVM_ENABLED)
     target_include_directories(emlang_compiler PRIVATE ${LLVM_INCLUDE_DIRS})
-    target_link_libraries(emlang_compiler ${LLVM_LIBRARIES})
+    target_link_libraries(emlang_compiler PRIVATE ${LLVM_LIBRARIES})
     target_compile_definitions(emlang_compiler PRIVATE LLVM_ENABLED)
+    message(STATUS "Linking emlang_compiler with LLVM libraries")
 else()
     target_compile_definitions(emlang_compiler PRIVATE NO_LLVM_CODEGEN)
+    message(STATUS "Building emlang_compiler without LLVM support")
 endif()

--- a/compiler/ast/CMakeLists.txt
+++ b/compiler/ast/CMakeLists.txt
@@ -44,6 +44,9 @@ set_target_properties(emlang_ast PROPERTIES
 
 # Compiler-specific flags
 if(MSVC)
+    target_compile_options(emlang_ast PRIVATE
+        /wd4251  # DLL interface warning for STL containers
+    )
     target_compile_options(emlang_ast PRIVATE /W4)
 else()
     target_compile_options(emlang_ast PRIVATE -Wall -Wextra -pedantic)

--- a/compiler/ast/ast_base.cpp
+++ b/compiler/ast/ast_base.cpp
@@ -7,18 +7,27 @@
 // Base AST node implementations
 //===----------------------------------------------------------------------===//
 
-#include "ast.h"
+#include "ast/ast_base.h"
+#include "ast/visitor.h"
 #include <sstream>
 
 namespace emlang {
 
 // ASTNode base class implementation
-ASTNode::ASTNode(ASTNodeType type, size_t line, size_t column)
+ASTNode::ASTNode(NodeType type, size_t line, size_t column)
     : type(type), line(line), column(column) {}
+
+// Expression base class implementation
+Expression::Expression(NodeType type, size_t line, size_t column)
+    : ASTNode(type, line, column) {}
+
+// Statement base class implementation
+Statement::Statement(NodeType type, size_t line, size_t column)
+    : ASTNode(type, line, column) {}
 
 // Program class implementation
 Program::Program(std::vector<StatementPtr> stmts) : 
-    ASTNode(ASTNodeType::PROGRAM, 0, 0), 
+    ASTNode(NodeType::PROGRAM, 0, 0), 
     statements(std::move(stmts)) {}
 
 std::string Program::toString() const {

--- a/compiler/ast/decl.cpp
+++ b/compiler/ast/decl.cpp
@@ -22,7 +22,7 @@ VariableDecl::VariableDecl(
     bool isConst, 
     size_t line, 
     size_t column
-) : Statement(ASTNodeType::VARIABLE_DECLARATION, line, column), 
+) : Statement(NodeType::VARIABLE_DECL, line, column), 
     name(name), 
     type(type), 
     initializer(std::move(init)), 
@@ -30,8 +30,8 @@ VariableDecl::VariableDecl(
 
 std::string VariableDecl::toString() const {
     std::string result = (isConstant ? "const " : "let ") + name;
-    if (!type.empty()) {
-        result += ": " + type;
+    if (type.has_value() && !type->empty()) {
+        result += ": " + type.value();
     }
     if (initializer) {
         result += " = " + initializer->toString();
@@ -49,13 +49,19 @@ FunctionDecl::FunctionDecl(
     std::vector<Parameter> params, 
     const std::string& retType, 
     StatementPtr body, 
+    bool Extern,
+    bool Async,
+    bool Unsafe,
     size_t line, 
     size_t column
-) : Statement(ASTNodeType::FUNCTION_DECLARATION, line, column), 
+) : Statement(NodeType::FUNCTION_DECL, line, column), 
     name(name), 
     parameters(std::move(params)), 
     returnType(retType), 
-    body(std::move(body)) {}
+    body(std::move(body)),
+    isExtern(Extern),
+    isAsync(Async),
+    isUnsafe(Unsafe) {}
 
 std::string FunctionDecl::toString() const {
     std::stringstream ss;
@@ -65,8 +71,8 @@ std::string FunctionDecl::toString() const {
         ss << parameters[i].name << ": " << parameters[i].type;
     }
     ss << ")";
-    if (!returnType.empty()) {
-        ss << ": " << returnType;
+    if (!returnType->empty()) {
+        ss << ": " << returnType.value();
     }
     ss << " " << body->toString() << ")";
     return ss.str();
@@ -83,7 +89,7 @@ ExternFunctionDecl::ExternFunctionDecl(
     const std::string& retType, 
     size_t line, 
     size_t column
-) : Statement(ASTNodeType::EXTERN_FUNCTION_DECLARATION, line, column), 
+) : Statement(NodeType::EXTERN_FN_DECL, line, column), 
     name(name), 
     parameters(std::move(params)), 
     returnType(retType) {}

--- a/compiler/ast/stmt.cpp
+++ b/compiler/ast/stmt.cpp
@@ -14,13 +14,9 @@
 
 namespace emlang {
 
-// Statement base class
-Statement::Statement(ASTNodeType type, size_t line, size_t column)
-    : ASTNode(type, line, column) {}
-
 // BlockStatement
 BlockStmt::BlockStmt(std::vector<StatementPtr> stmts, size_t line, size_t column)
-    : Statement(ASTNodeType::BLOCK_STATEMENT, line, column), statements(std::move(stmts)) {}
+    : Statement(NodeType::BLOCK_STMT, line, column), statements(std::move(stmts)) {}
 
 std::string BlockStmt::toString() const {
     std::stringstream ss;
@@ -39,7 +35,7 @@ void BlockStmt::accept(ASTVisitor& visitor) {
 
 // IfStatement
 IfStmt::IfStmt(ExpressionPtr cond, StatementPtr then, StatementPtr else_, size_t line, size_t column)
-    : Statement(ASTNodeType::IF_STATEMENT, line, column), 
+    : Statement(NodeType::IF_STMT, line, column), 
       condition(std::move(cond)), 
       thenBranch(std::move(then)), 
       elseBranch(std::move(else_)) {}
@@ -59,7 +55,7 @@ void IfStmt::accept(ASTVisitor& visitor) {
 
 // WhileStatement
 WhileStmt::WhileStmt(ExpressionPtr cond, StatementPtr body, size_t line, size_t column)
-    : Statement(ASTNodeType::WHILE_STATEMENT, line, column), 
+    : Statement(NodeType::WHILE_STMT, line, column), 
       condition(std::move(cond)), 
       body(std::move(body)) {}
 
@@ -73,7 +69,7 @@ void WhileStmt::accept(ASTVisitor& visitor) {
 
 // ReturnStatement
 ReturnStmt::ReturnStmt(ExpressionPtr val, size_t line, size_t column)
-    : Statement(ASTNodeType::RETURN_STATEMENT, line, column), value(std::move(val)) {}
+    : Statement(NodeType::RETURN_STMT, line, column), value(std::move(val)) {}
 
 std::string ReturnStmt::toString() const {
     if (value) {
@@ -88,13 +84,36 @@ void ReturnStmt::accept(ASTVisitor& visitor) {
 
 // ExpressionStatement
 ExpressionStmt::ExpressionStmt(ExpressionPtr expr, size_t line, size_t column)
-    : Statement(ASTNodeType::EXPRESSION_STMT, line, column), expression(std::move(expr)) {}
+    : Statement(NodeType::EXPRESSION_STMT, line, column), expression(std::move(expr)) {}
 
 std::string ExpressionStmt::toString() const {
     return "ExprStmt(" + expression->toString() + ")";
 }
 
 void ExpressionStmt::accept(ASTVisitor& visitor) {
+    visitor.visit(*this);
+}
+
+// ForStatement
+ForStmt::ForStmt(StatementPtr init, ExpressionPtr cond, ExpressionPtr incr, StatementPtr body, size_t line, size_t column)
+    : Statement(NodeType::FOR_STMT, line, column), 
+      initializer(std::move(init)), 
+      condition(std::move(cond)), 
+      increment(std::move(incr)), 
+      body(std::move(body)) {}
+
+std::string ForStmt::toString() const {
+    std::string result = "For(";
+    if (initializer) result += initializer->toString();
+    result += "; ";
+    if (condition) result += condition->toString();
+    result += "; ";
+    if (increment) result += increment->toString();
+    result += "; " + body->toString() + ")";
+    return result;
+}
+
+void ForStmt::accept(ASTVisitor& visitor) {
     visitor.visit(*this);
 }
 

--- a/compiler/codegen/CMakeLists.txt
+++ b/compiler/codegen/CMakeLists.txt
@@ -124,15 +124,6 @@ if(ORCJIT_ENABLED)
         EMLANG_LLVM_VERSION_MAJOR=${LLVM_VERSION_MAJOR}
         EMLANG_LLVM_VERSION_MINOR=${LLVM_VERSION_MINOR}
     )
-    
-    # Advanced OrcJIT features based on LLVM version
-    if(LLVM_PACKAGE_VERSION VERSION_GREATER_EQUAL "12.0")
-        target_compile_definitions(emlang_codegen PRIVATE EMLANG_ORCJIT_ADVANCED)
-    endif()
-    
-    if(LLVM_PACKAGE_VERSION VERSION_GREATER_EQUAL "14.0")
-        target_compile_definitions(emlang_codegen PRIVATE EMLANG_ORCJIT_LATEST)
-    endif()
 
     message(STATUS "Codegen module configuration:")
     message(STATUS "  LLVM Version: ${LLVM_PACKAGE_VERSION}")
@@ -140,14 +131,6 @@ if(ORCJIT_ENABLED)
     message(STATUS "  Target Platform: ${CMAKE_SYSTEM_NAME}")
     message(STATUS "  Compiler: ${CMAKE_CXX_COMPILER_ID}")
     message(STATUS "  Build Type: ${CMAKE_BUILD_TYPE}")
-    
-else()
-    # Fallback mode without LLVM
-    target_compile_definitions(emlang_codegen PUBLIC 
-        EMLANG_NO_LLVM_CODEGEN
-        EMLANG_ORCJIT_DISABLED
-    )
-    message(STATUS "Building codegen module without LLVM OrcJIT support")
 endif()
 
 # Platform-specific configurations
@@ -236,15 +219,7 @@ endif()
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     target_compile_definitions(emlang_codegen PRIVATE
         EMLANG_DEBUG_MODE
-        EMLANG_JIT_DEBUG
     )
-    
-    # Enable debug information for JIT
-    if(ORCJIT_ENABLED)
-        target_compile_definitions(emlang_codegen PRIVATE
-            EMLANG_JIT_DEBUG_INFO
-        )
-    endif()
 endif()
 
 # Installation rules

--- a/compiler/codegen/builtins_integration.cpp
+++ b/compiler/codegen/builtins_integration.cpp
@@ -1,0 +1,444 @@
+//===--- builtins_integration.cpp - Builtins Integration ------*- C++ -*-===//
+//
+// Part of the EMLang Project, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Integration with existing builtins.h/cpp system for advanced JIT
+//
+// This file provides integration between the modular codegen system and
+// the existing builtin functions infrastructure, enabling seamless symbol
+// resolution and runtime binding for both AOT and JIT compilation.
+//===----------------------------------------------------------------------===//
+
+#include "../../include/codegen/symbol_resolver.h"
+#include "../../include/codegen/jit_engine.h"
+#include "../../include/builtins.h"
+#include "../../include/codegen/codegen_error.h"
+
+// Disable LLVM warnings for includes
+#ifdef _MSC_VER
+    #pragma warning(push)
+    #pragma warning(disable: 4624) // destructor was implicitly deleted
+    #pragma warning(disable: 4244) // conversion warnings
+    #pragma warning(disable: 4267) // size_t conversion warnings
+#endif
+
+#ifdef EMLANG_ORCJIT_ENABLED
+#include <llvm/IR/Function.h>
+#include <llvm/IR/Type.h>
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/ExecutionEngine/Orc/Core.h>
+#include <llvm/ExecutionEngine/Orc/ExecutionUtils.h>
+#endif
+
+#ifdef _MSC_VER
+    #pragma warning(pop)
+#endif
+
+#include <unordered_map>
+#include <functional>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <cmath>
+
+namespace emlang {
+
+// ======================== BUILTIN FUNCTION IMPLEMENTATIONS ========================
+
+// External C-style implementations for builtin functions
+extern "C" {
+    // I/O Functions
+    void emlang_print_str(const char* str) {
+        if (str) {
+            std::cout << str;
+        }
+    }
+    
+    void emlang_print_int(int32_t value) {
+        std::cout << value;
+    }
+    
+    void emlang_print_char(char c) {
+        std::cout << c;
+    }
+    
+    void emlang_print_float(float value) {
+        std::cout << value;
+    }
+    
+    void emlang_println() {
+        std::cout << std::endl;
+    }
+    
+    // Input Functions
+    int32_t emlang_read_int() {
+        int32_t value;
+        std::cin >> value;
+        return value;
+    }
+    
+    char emlang_read_char() {
+        char c;
+        std::cin >> c;
+        return c;
+    }
+    
+    float emlang_read_float() {
+        float value;
+        std::cin >> value;
+        return value;
+    }
+    
+    // Memory Functions
+    void* emlang_malloc(int32_t size) {
+        return std::malloc(static_cast<size_t>(size));
+    }
+    
+    void emlang_free(void* ptr) {
+        if (ptr) {
+            std::free(ptr);
+        }
+    }
+    
+    void* emlang_memset(void* ptr, int32_t value, int32_t size) {
+        return std::memset(ptr, value, static_cast<size_t>(size));
+    }
+    
+    // String Functions
+    int32_t emlang_strlen(const char* str) {
+        return str ? static_cast<int32_t>(std::strlen(str)) : 0;
+    }
+    
+    int32_t emlang_strcmp(const char* str1, const char* str2) {
+        if (!str1 || !str2) return str1 == str2 ? 0 : (str1 ? 1 : -1);
+        return std::strcmp(str1, str2);
+    }
+    
+    // Math Functions
+    int32_t emlang_pow(int32_t base, int32_t exp) {
+        return static_cast<int32_t>(std::pow(base, exp));
+    }
+    
+    int32_t emlang_sqrt(int32_t x) {
+        return static_cast<int32_t>(std::sqrt(x));
+    }
+    
+    double emlang_sin(double x) {
+        return std::sin(x);
+    }
+    
+    double emlang_cos(double x) {
+        return std::cos(x);
+    }
+    
+    int32_t emlang_abs(int32_t x) {
+        return std::abs(x);
+    }
+    
+    int32_t emlang_min(int32_t a, int32_t b) {
+        return (a < b) ? a : b;
+    }
+    
+    int32_t emlang_max(int32_t a, int32_t b) {
+        return (a > b) ? a : b;
+    }
+}
+
+// ======================== BUILTIN INTEGRATION MANAGER ========================
+
+/**
+ * @class BuiltinIntegrationManager
+ * @brief Manages integration between builtins and JIT/AOT compilation
+ */
+class BuiltinIntegrationManager {
+private:
+    std::unordered_map<std::string, void*> functionMap_;
+    bool isInitialized_;
+    
+public:
+    BuiltinIntegrationManager() : isInitialized_(false) {}
+    
+    /**
+     * @brief Initialize the builtin integration system
+     */
+    void initialize() {
+        if (isInitialized_) return;
+        
+        // Register all builtin function pointers
+        functionMap_["emlang_print"] = reinterpret_cast<void*>(emlang_print_str);
+        functionMap_["emlang_print_str"] = reinterpret_cast<void*>(emlang_print_str);
+        functionMap_["emlang_print_int"] = reinterpret_cast<void*>(emlang_print_int);
+        functionMap_["emlang_print_char"] = reinterpret_cast<void*>(emlang_print_char);
+        functionMap_["emlang_print_float"] = reinterpret_cast<void*>(emlang_print_float);
+        functionMap_["emlang_println"] = reinterpret_cast<void*>(emlang_println);
+        
+        functionMap_["emlang_read_int"] = reinterpret_cast<void*>(emlang_read_int);
+        functionMap_["emlang_read_char"] = reinterpret_cast<void*>(emlang_read_char);
+        functionMap_["emlang_read_float"] = reinterpret_cast<void*>(emlang_read_float);
+        
+        functionMap_["emlang_malloc"] = reinterpret_cast<void*>(emlang_malloc);
+        functionMap_["emlang_free"] = reinterpret_cast<void*>(emlang_free);
+        functionMap_["emlang_memset"] = reinterpret_cast<void*>(emlang_memset);
+        
+        functionMap_["emlang_strlen"] = reinterpret_cast<void*>(emlang_strlen);
+        functionMap_["emlang_strcmp"] = reinterpret_cast<void*>(emlang_strcmp);
+        
+        functionMap_["emlang_pow"] = reinterpret_cast<void*>(emlang_pow);
+        functionMap_["emlang_sqrt"] = reinterpret_cast<void*>(emlang_sqrt);
+        functionMap_["emlang_sin"] = reinterpret_cast<void*>(emlang_sin);
+        functionMap_["emlang_cos"] = reinterpret_cast<void*>(emlang_cos);
+        functionMap_["emlang_abs"] = reinterpret_cast<void*>(emlang_abs);
+        functionMap_["emlang_min"] = reinterpret_cast<void*>(emlang_min);
+        functionMap_["emlang_max"] = reinterpret_cast<void*>(emlang_max);
+        
+        isInitialized_ = true;
+    }
+    
+    /**
+     * @brief Get function pointer for a builtin function
+     */
+    void* getFunctionPointer(const std::string& name) {
+        if (!isInitialized_) initialize();
+        
+        auto it = functionMap_.find(name);
+        return (it != functionMap_.end()) ? it->second : nullptr;
+    }
+    
+    /**
+     * @brief Get all registered builtin functions
+     */
+    const std::unordered_map<std::string, void*>& getAllFunctions() {
+        if (!isInitialized_) initialize();
+        return functionMap_;
+    }
+    
+    /**
+     * @brief Check if a function is a registered builtin
+     */
+    bool hasFunction(const std::string& name) {
+        if (!isInitialized_) initialize();
+        return functionMap_.find(name) != functionMap_.end();
+    }
+};
+
+// Global instance
+static BuiltinIntegrationManager g_builtinManager;
+
+// ======================== PUBLIC INTEGRATION API ========================
+
+namespace builtins {
+
+void initializeBuiltinIntegration() {
+    g_builtinManager.initialize();
+}
+
+void* getBuiltinFunctionPointer(const std::string& name) {
+    return g_builtinManager.getFunctionPointer(name);
+}
+
+bool isBuiltinFunctionAvailable(const std::string& name) {
+    return g_builtinManager.hasFunction(name);
+}
+
+std::vector<std::string> getAvailableBuiltinFunctions() {
+    const auto& functions = g_builtinManager.getAllFunctions();
+    std::vector<std::string> names;
+    names.reserve(functions.size());
+    
+    for (const auto& pair : functions) {
+        names.push_back(pair.first);
+    }
+    
+    return names;
+}
+
+#ifdef EMLANG_ORCJIT_ENABLED
+
+llvm::Error registerBuiltinsWithJIT(JITEngine& jitEngine) {
+    // Initialize builtin integration if not already done
+    g_builtinManager.initialize();
+    
+    // Register all builtin functions with the JIT engine
+    const auto& functions = g_builtinManager.getAllFunctions();
+    
+    for (const auto& pair : functions) {
+        auto error = jitEngine.addSymbol(pair.first, 
+                                       reinterpret_cast<uint64_t>(pair.second));
+        if (error) {
+            return error;
+        }
+    }
+    
+    return llvm::Error::success();
+}
+
+llvm::Error registerBuiltinsWithResolver(SymbolResolver& resolver) {
+    // Initialize builtin integration if not already done
+    g_builtinManager.initialize();
+    
+    // Register all builtin functions with the symbol resolver
+    const auto& functions = g_builtinManager.getAllFunctions();
+    
+    for (const auto& pair : functions) {
+        auto error = resolver.addBuiltinFunction(pair.first, 
+                                               reinterpret_cast<uint64_t>(pair.second));
+        if (error) {
+            return error;
+        }
+    }
+    
+    return llvm::Error::success();
+}
+
+llvm::Type* getBuiltinFunctionType(const std::string& name, llvm::LLVMContext& context) {
+    const BuiltinFunction* builtin = getBuiltinFunction(name);
+    if (!builtin) {
+        return nullptr;
+    }
+      // Convert EMLang types to LLVM types
+    auto convertType = [&](const std::string& type) -> llvm::Type* {
+        if (type == "void") return llvm::Type::getVoidTy(context);
+        if (type == "int32") return llvm::Type::getInt32Ty(context);
+        if (type == "char") return llvm::Type::getInt8Ty(context);
+        if (type == "float") return llvm::Type::getFloatTy(context);
+        if (type == "double") return llvm::Type::getDoubleTy(context);
+        if (type == "string" || type == "void*") return llvm::PointerType::get(context, 0);
+        
+        // Default to i8* for unknown types
+        return llvm::PointerType::get(context, 0);
+    };
+    
+    // Build parameter types
+    std::vector<llvm::Type*> paramTypes;
+    for (const auto& param : builtin->parameters) {
+        paramTypes.push_back(convertType(param.type));
+    }
+    
+    // Build return type
+    llvm::Type* returnType = convertType(builtin->returnType);
+    
+    // Create function type
+    return llvm::FunctionType::get(returnType, paramTypes, false);
+}
+
+#endif // EMLANG_ORCJIT_ENABLED
+
+} // namespace builtins
+
+// ======================== LEGACY COMPATIBILITY ========================
+
+// Provide backward compatibility with existing builtin system
+namespace {
+
+class BuiltinIntegrationBridge {
+public:
+    static void ensureInitialized() {
+        static bool initialized = false;
+        if (!initialized) {
+            builtins::initializeBuiltinIntegration();
+            initialized = true;
+        }
+    }
+    
+    static void* getFunctionAddress(const std::string& name) {
+        ensureInitialized();
+        return builtins::getBuiltinFunctionPointer(name);
+    }
+};
+
+} // anonymous namespace
+
+// ======================== INTEGRATION WITH CODEGEN ========================
+
+namespace codegen {
+
+class BuiltinCodegenIntegration {
+public:
+    /**
+     * @brief Initialize builtin integration for codegen
+     */
+    static CodegenError initializeBuiltins() {
+        try {
+            builtins::initializeBuiltinIntegration();
+            return CodegenError::success();
+        } catch (const std::exception& e) {
+            return CodegenError::createBuiltinError("Failed to initialize builtins: " + std::string(e.what()));
+        }
+    }
+    
+    /**
+     * @brief Get builtin function address for AOT compilation
+     */
+    static void* getBuiltinAddress(const std::string& name) {
+        return builtins::getBuiltinFunctionPointer(name);
+    }
+    
+    /**
+     * @brief Check if a symbol is a builtin function
+     */
+    static bool isBuiltinSymbol(const std::string& name) {
+        return builtins::isBuiltinFunctionAvailable(name);
+    }
+    
+#ifdef EMLANG_ORCJIT_ENABLED
+    /**
+     * @brief Register all builtins with a JIT engine
+     */
+    static CodegenError registerWithJIT(JITEngine& jit) {
+        try {
+            auto error = builtins::registerBuiltinsWithJIT(jit);
+            if (error) {
+                return CodegenError::createJITError("Failed to register builtins with JIT: " + 
+                                                  llvm::toString(std::move(error)));
+            }
+            return CodegenError::success();
+        } catch (const std::exception& e) {
+            return CodegenError::createJITError("Exception during builtin JIT registration: " + 
+                                              std::string(e.what()));
+        }
+    }
+    
+    /**
+     * @brief Register all builtins with a symbol resolver
+     */
+    static CodegenError registerWithResolver(SymbolResolver& resolver) {
+        try {
+            auto error = builtins::registerBuiltinsWithResolver(resolver);
+            if (error) {
+                return CodegenError::createSymbolError("Failed to register builtins with resolver: " + 
+                                                     llvm::toString(std::move(error)));
+            }
+            return CodegenError::success();
+        } catch (const std::exception& e) {
+            return CodegenError::createSymbolError("Exception during builtin resolver registration: " + 
+                                                 std::string(e.what()));
+        }
+    }
+#endif
+};
+
+} // namespace codegen
+
+} // namespace emlang
+
+// ======================== C API COMPATIBILITY ========================
+
+extern "C" {
+
+EMLANG_API void emlang_initialize_builtin_integration() {
+    emlang::builtins::initializeBuiltinIntegration();
+}
+
+EMLANG_API void* emlang_get_builtin_function_pointer(const char* name) {
+    if (!name) return nullptr;
+    return emlang::builtins::getBuiltinFunctionPointer(std::string(name));
+}
+
+EMLANG_API int emlang_is_builtin_function_available(const char* name) {
+    if (!name) return 0;
+    return emlang::builtins::isBuiltinFunctionAvailable(std::string(name)) ? 1 : 0;
+}
+
+} // extern "C"

--- a/compiler/codegen/codegen_error.cpp
+++ b/compiler/codegen/codegen_error.cpp
@@ -1,0 +1,253 @@
+//===--- codegen_error.cpp - Code Generation Error Handling ----*- C++ -*-===//
+//
+// Part of the RNR Project, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Implementation of error handling for EMLang code generation
+//===----------------------------------------------------------------------===//
+
+#include "../../include/codegen/codegen_error.h"
+#include <iostream>
+#include <sstream>
+#include <map>
+
+namespace emlang {
+
+// ======================== CodegenError Implementation ========================
+
+CodegenError::CodegenError(CodegenErrorType type, const std::string& message, const std::string& context)
+    : std::runtime_error(message), type_(type), context_(context) {}
+
+std::string CodegenError::getFormattedMessage() const {
+    std::ostringstream oss;
+    
+    // Add error type prefix
+    oss << "[" << CodegenError::errorTypeToString(type_) << "] ";
+    
+    // Add main message
+    oss << what();
+    
+    // Add context if available
+    if (!context_.empty()) {
+        oss << " (Context: " << context_ << ")";
+    }
+    
+    return oss.str();
+}
+
+std::string CodegenError::errorTypeToString(CodegenErrorType type) {
+    switch (type) {
+        case CodegenErrorType::UnknownType:
+            return "UNKNOWN TYPE";
+        case CodegenErrorType::TypeMismatch:
+            return "TYPE MISMATCH";
+        case CodegenErrorType::InvalidPointerOperation:
+            return "INVALID POINTER OPERATION";
+        case CodegenErrorType::InvalidCast:
+            return "INVALID CAST";
+        case CodegenErrorType::UndefinedVariable:
+            return "UNDEFINED VARIABLE";
+        case CodegenErrorType::UndefinedFunction:
+            return "UNDEFINED FUNCTION";
+        case CodegenErrorType::DuplicateSymbol:
+            return "DUPLICATE SYMBOL";
+        case CodegenErrorType::InvalidSymbolReference:
+            return "INVALID SYMBOL REFERENCE";
+        case CodegenErrorType::InvalidReturn:
+            return "INVALID RETURN";
+        case CodegenErrorType::UnreachableCode:
+            return "UNREACHABLE CODE";
+        case CodegenErrorType::InvalidBranch:
+            return "INVALID BRANCH";
+        case CodegenErrorType::ArgumentCountMismatch:
+            return "ARGUMENT COUNT MISMATCH";
+        case CodegenErrorType::ParameterTypeMismatch:
+            return "PARAMETER TYPE MISMATCH";
+        case CodegenErrorType::InvalidFunctionCall:
+            return "INVALID FUNCTION CALL";
+        case CodegenErrorType::MissingMainFunction:
+            return "MISSING MAIN FUNCTION";
+        case CodegenErrorType::InvalidMemoryAccess:
+            return "INVALID MEMORY ACCESS";
+        case CodegenErrorType::NullPointerDereference:
+            return "NULL POINTER DEREFERENCE";
+        case CodegenErrorType::MemoryAllocationFailure:
+            return "MEMORY ALLOCATION FAILURE";
+        case CodegenErrorType::LLVMGenerationError:
+            return "LLVM GENERATION ERROR";
+        case CodegenErrorType::LLVMVerificationError:
+            return "LLVM VERIFICATION ERROR";
+        case CodegenErrorType::OptimizationFailure:
+            return "OPTIMIZATION FAILURE";
+        case CodegenErrorType::ObjectFileGenerationError:
+            return "OBJECT FILE GENERATION ERROR";
+        case CodegenErrorType::InternalError:
+            return "INTERNAL ERROR";
+        case CodegenErrorType::NotImplemented:
+            return "NOT IMPLEMENTED";
+        default:
+            return "UNKNOWN ERROR";
+    }
+}
+
+// ======================== CodegenErrorReporter Implementation ========================
+
+CodegenErrorReporter::CodegenErrorReporter() : immediateOutput_(false) {}
+
+void CodegenErrorReporter::error(const std::string& message) {
+    error(CodegenErrorType::InternalError, message);
+}
+
+void CodegenErrorReporter::error(CodegenErrorType type, const std::string& message, const std::string& context) {
+    std::string fullContext = context.empty() ? getCurrentContextString() : context;
+    CodegenError error(type, message, fullContext);
+    errors_.push_back(error);
+    
+    if (immediateOutput_) {
+        std::cerr << error.getFormattedMessage() << std::endl;
+    }
+}
+
+void CodegenErrorReporter::warning(const std::string& message) {
+    warnings_.push_back(message);
+    
+    if (immediateOutput_) {
+        std::cerr << "[WARNING] " << message << std::endl;
+    }
+}
+
+void CodegenErrorReporter::info(const std::string& message) {
+    if (immediateOutput_) {
+        std::cerr << "[INFO] " << message << std::endl;
+    }
+}
+
+bool CodegenErrorReporter::hasErrors() const {
+    return !errors_.empty();
+}
+
+size_t CodegenErrorReporter::getErrorCount() const {
+    return errors_.size();
+}
+
+size_t CodegenErrorReporter::getWarningCount() const {
+    return warnings_.size();
+}
+
+const std::vector<CodegenError>& CodegenErrorReporter::getErrors() const {
+    return errors_;
+}
+
+void CodegenErrorReporter::clearErrors() {
+    errors_.clear();
+    warnings_.clear();
+}
+
+void CodegenErrorReporter::setImmediateOutput(bool immediate) {
+    immediateOutput_ = immediate;
+}
+
+void CodegenErrorReporter::printErrors(std::ostream& stream) const {
+    stream << "=== Code Generation Errors ===" << std::endl;
+    for (const auto& error : errors_) {
+        stream << error.getFormattedMessage() << std::endl;
+    }
+}
+
+void CodegenErrorReporter::printWarnings(std::ostream& stream) const {
+    stream << "=== Code Generation Warnings ===" << std::endl;
+    for (const auto& warning : warnings_) {
+        stream << "[WARNING] " << warning << std::endl;
+    }
+}
+
+void CodegenErrorReporter::printSummary(std::ostream& stream) const {
+    if (!hasErrors() && warnings_.empty()) {
+        stream << "No code generation errors or warnings." << std::endl;
+        return;
+    }
+    
+    stream << "======================================" << std::endl;
+    stream << "    Code Generation Summary          " << std::endl;
+    stream << "======================================" << std::endl;
+    stream << "Errors: " << errors_.size() << std::endl;
+    stream << "Warnings: " << warnings_.size() << std::endl;
+    
+    if (!errors_.empty()) {
+        // Count errors by type
+        std::map<CodegenErrorType, int> errorCounts;
+        for (const auto& error : errors_) {
+            errorCounts[error.getType()]++;
+        }
+        
+        stream << "Error breakdown:" << std::endl;
+        for (const auto& pair : errorCounts) {
+            stream << "  " << errorTypeToString(pair.first) << ": " << pair.second << std::endl;
+        }
+        
+        stream << "======================================" << std::endl;
+        printErrors(stream);
+    }
+    
+    if (!warnings_.empty()) {
+        stream << "======================================" << std::endl;
+        printWarnings(stream);
+    }
+    
+    stream << "======================================" << std::endl;
+}
+
+void CodegenErrorReporter::setContext(const std::string& context) {
+    contextStack_.clear();
+    contextStack_.push_back(context);
+}
+
+const std::string& CodegenErrorReporter::getContext() const {
+    static const std::string empty;
+    return contextStack_.empty() ? empty : contextStack_.back();
+}
+
+void CodegenErrorReporter::pushContext(const std::string& context) {
+    contextStack_.push_back(context);
+}
+
+void CodegenErrorReporter::popContext() {
+    if (!contextStack_.empty()) {
+        contextStack_.pop_back();
+    }
+}
+
+std::string CodegenErrorReporter::errorTypeToString(CodegenErrorType type) const {
+    return CodegenError::errorTypeToString(type);
+}
+
+std::string CodegenErrorReporter::getCurrentContextString() const {
+    if (contextStack_.empty()) {
+        return "";
+    }
+    
+    std::ostringstream oss;
+    for (size_t i = 0; i < contextStack_.size(); ++i) {
+        if (i > 0) oss << " -> ";
+        oss << contextStack_[i];
+    }
+    return oss.str();
+}
+
+// ======================== Utility Functions ========================
+
+std::string makeTypeMismatchError(const std::string& expected, const std::string& actual) {
+    return "Expected type '" + expected + "', but got '" + actual + "'";
+}
+
+std::string makeUndefinedSymbolError(const std::string& symbolName, const std::string& symbolType) {
+    return "Undefined " + symbolType + " '" + symbolName + "'";
+}
+
+std::string makeArgumentCountError(const std::string& functionName, size_t expected, size_t actual) {
+    return "Function '" + functionName + "' expects " + std::to_string(expected) + 
+           " arguments, but got " + std::to_string(actual);
+}
+
+} // namespace emlang

--- a/compiler/emlang_compiler.rc
+++ b/compiler/emlang_compiler.rc
@@ -23,7 +23,7 @@ BEGIN
             VALUE "LegalCopyright",    EMLANG_COPYRIGHT "\0"
             VALUE "OriginalFilename",  EMLANG_COMPILER_FILENAME "\0"
             VALUE "ProductName",       EMLANG_COMPILER_NAME "\0"
-            VALUE "ProductVersion",    "0\0"
+            VALUE "ProductVersion",    "1.0.0-alpha.3 (25f737f)\0"
             VALUE "Comments",          EMLANG_COMMENTS "\0"
         END
     END

--- a/compiler/lexer/CMakeLists.txt
+++ b/compiler/lexer/CMakeLists.txt
@@ -36,6 +36,9 @@ set_target_properties(emlang_lexer PROPERTIES
 
 # Add compiler-specific flags
 if(MSVC)
+    target_compile_options(emlang_lexer PRIVATE
+        /wd4251  # DLL interface warning for STL containers
+    )
     target_compile_options(emlang_lexer PRIVATE /W4)
 else()
     target_compile_options(emlang_lexer PRIVATE -Wall -Wextra -pedantic)

--- a/compiler/lexer/lexer.cpp
+++ b/compiler/lexer/lexer.cpp
@@ -70,11 +70,17 @@ std::string Lexer::readNumber() {
 
 std::string Lexer::readString() {
     std::string str;
+    str.reserve(64); // Reserve space for performance
     advance(); // skip opening double quote
     
     while (currentChar != '\0' && currentChar != '"') {
         if (currentChar == '\\') {
             advance();
+            if (currentChar == '\0') {
+                error("Unterminated escape sequence in string literal");
+                break;
+            }
+            
             switch (currentChar) {
                 case 'n': str += '\n'; break;
                 case 't': str += '\t'; break;
@@ -82,7 +88,65 @@ std::string Lexer::readString() {
                 case '\\': str += '\\'; break;
                 case '"': str += '"'; break;
                 case '\'': str += '\''; break;
-                default: str += currentChar; break;
+                case '0': str += '\0'; break;
+                case 'u': {
+                    // Enhanced Unicode support
+                    advance();
+                    if (currentChar != '{') {
+                        error("Expected '{' after \\u in Unicode escape");
+                        break;
+                    }
+                    advance();
+                    
+                    std::string hexCode;
+                    hexCode.reserve(8);
+                    
+                    while (currentChar != '\0' && currentChar != '}' && hexCode.length() < 8) {
+                        if (std::isxdigit(currentChar)) {
+                            hexCode += currentChar;
+                            advance();
+                        } else {
+                            error("Invalid hex digit in Unicode escape");
+                            break;
+                        }
+                    }
+                    
+                    if (currentChar == '}' && !hexCode.empty()) {
+                        try {
+                            unsigned long codepoint = std::stoul(hexCode, nullptr, 16);
+                            if (codepoint <= 0x10FFFF) {
+                                // Convert to UTF-8
+                                if (codepoint <= 0x7F) {
+                                    str += static_cast<char>(codepoint);
+                                } else if (codepoint <= 0x7FF) {
+                                    str += static_cast<char>(0xC0 | (codepoint >> 6));
+                                    str += static_cast<char>(0x80 | (codepoint & 0x3F));
+                                } else if (codepoint <= 0xFFFF) {
+                                    str += static_cast<char>(0xE0 | (codepoint >> 12));
+                                    str += static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F));
+                                    str += static_cast<char>(0x80 | (codepoint & 0x3F));
+                                } else {
+                                    str += static_cast<char>(0xF0 | (codepoint >> 18));
+                                    str += static_cast<char>(0x80 | ((codepoint >> 12) & 0x3F));
+                                    str += static_cast<char>(0x80 | ((codepoint >> 6) & 0x3F));
+                                    str += static_cast<char>(0x80 | (codepoint & 0x3F));
+                                }
+                            } else {
+                                error("Unicode codepoint out of range");
+                            }
+                        } catch (const std::exception&) {
+                            error("Invalid Unicode escape sequence");
+                        }
+                    } else {
+                        error("Malformed Unicode escape sequence");
+                    }
+                    break;
+                }
+                default: 
+                    // Preserve unknown escape sequences
+                    str += '\\';
+                    str += currentChar; 
+                    break;
             }
         } else {
             str += currentChar;
@@ -132,41 +196,67 @@ Token Lexer::nextToken() {
             return Token(TokenType::NEWLINE, "\\n", tokenLine, tokenColumn);
         }
         
-        // Handle comments
-        if (currentChar == '/' && position + 1 < source.length() && 
-            (source[position + 1] == '/' || source[position + 1] == '*')) {
-            skipComment();
-            continue;
+        // Handle comments (single-line, multi-line, and doc comments)
+        if (currentChar == '/' && position + 1 < source.length()) {
+            char nextChar = source[position + 1];
+            if (nextChar == '/') {
+                skipComment();
+                continue;
+            } else if (nextChar == '*') {
+                // Check for doc comment (/**)
+                if (position + 2 < source.length() && source[position + 2] == '*') {
+                    skipComment();
+                    continue;
+                } else {
+                    skipComment();
+                    continue;
+                }
+            }
         }
         
         // Numbers
         if (std::isdigit(currentChar)) {
             std::string number = readNumber();
-            return Token(TokenType::NUMBER, number, tokenLine, tokenColumn);
-        }
-          // Strings (double quotes)
-        if (currentChar == '"') {
-            std::string str = readString();
-            return Token(TokenType::STRING, str, tokenLine, tokenColumn);
+            // Determine if it's integer or float based on content
+            TokenType numberType = (number.find('.') != std::string::npos) ? TokenType::FLOAT : TokenType::INT;
+            return Token(numberType, number, tokenLine, tokenColumn);
         }
         
-        // Character literals (single quotes)
+        // String literals (double quotes) with Unicode support
+        if (currentChar == '"') {
+            std::string str = readString();
+            return Token(TokenType::STR, str, tokenLine, tokenColumn);
+        }
+        
+        // Character literals (single quotes) with Unicode support
         if (currentChar == '\'') {
             std::string charLit = readCharLiteral();
-            return Token(TokenType::CHAR_LITERAL, charLit, tokenLine, tokenColumn);
+            return Token(TokenType::CHAR, charLit, tokenLine, tokenColumn);
         }
         
         // Identifiers and keywords
         if (std::isalpha(currentChar) || currentChar == '_') {
             std::string identifier = readIdentifier();
+            
+            // Special handling for boolean literals
+            if (identifier == "true" || identifier == "false") {
+                return Token(TokenType::BOOL, identifier, tokenLine, tokenColumn);
+            }
+            
+            // Special handling for null literal
+            if (identifier == "null") {
+                return Token(TokenType::NULL_LITERAL, identifier, tokenLine, tokenColumn);
+            }
+            
             TokenType type = getKeywordType(identifier);
             return Token(type, identifier, tokenLine, tokenColumn);
         }
         
-        // Two-character operators
+        // Multi-character operators
         if (position + 1 < source.length()) {
             std::string twoChar = std::string(1, currentChar) + source[position + 1];
             
+            // Comparison operators
             if (twoChar == "==") {
                 advance(); advance();
                 return Token(TokenType::EQUAL, "==", tokenLine, tokenColumn);
@@ -179,38 +269,53 @@ Token Lexer::nextToken() {
             } else if (twoChar == ">=") {
                 advance(); advance();
                 return Token(TokenType::GREATER_EQUAL, ">=", tokenLine, tokenColumn);
-            } else if (twoChar == "&&") {
+            }
+            // Logical operators
+            else if (twoChar == "&&") {
                 advance(); advance();
                 return Token(TokenType::LOGICAL_AND, "&&", tokenLine, tokenColumn);
             } else if (twoChar == "||") {
                 advance(); advance();
                 return Token(TokenType::LOGICAL_OR, "||", tokenLine, tokenColumn);
             }
+            // Bitwise shift operators
+            else if (twoChar == "<<") {
+                advance(); advance();
+                return Token(TokenType::LEFT_SHIFT, "<<", tokenLine, tokenColumn);
+            } else if (twoChar == ">>") {
+                advance(); advance();
+                return Token(TokenType::RIGHT_SHIFT, ">>", tokenLine, tokenColumn);
+            }
         }
-          // Single-character tokens
+        
+        // Single-character tokens
         switch (currentChar) {
+            // Arithmetic operators
             case '+': advance(); return Token(TokenType::PLUS, "+", tokenLine, tokenColumn);
             case '-': advance(); return Token(TokenType::MINUS, "-", tokenLine, tokenColumn);
             case '*': advance(); return Token(TokenType::MULTIPLY, "*", tokenLine, tokenColumn);
-            case '/': 
-                // Check if it's a comment first
-                if (position + 1 < source.length() && 
-                    (source[position + 1] == '/' || source[position + 1] == '*')) {
-                    skipComment();
-                    continue;
-                } else {
-                    advance(); 
-                    return Token(TokenType::DIVIDE, "/", tokenLine, tokenColumn);
-                }
+            case '/': advance(); return Token(TokenType::DIVIDE, "/", tokenLine, tokenColumn);
             case '%': advance(); return Token(TokenType::MODULO, "%", tokenLine, tokenColumn);
+            
+            // Assignment and comparison
             case '=': advance(); return Token(TokenType::ASSIGN, "=", tokenLine, tokenColumn);
             case '<': advance(); return Token(TokenType::LESS_THAN, "<", tokenLine, tokenColumn);
-            case '>': advance(); return Token(TokenType::GREATER_THAN, ">", tokenLine, tokenColumn);            case '!': advance(); return Token(TokenType::LOGICAL_NOT, "!", tokenLine, tokenColumn);
-            case '&': advance(); return Token(TokenType::AMPERSAND, "&", tokenLine, tokenColumn);
+            case '>': advance(); return Token(TokenType::GREATER_THAN, ">", tokenLine, tokenColumn);
+            
+            // Logical and bitwise operators
+            case '!': advance(); return Token(TokenType::LOGICAL_NOT, "!", tokenLine, tokenColumn);
+            case '&': advance(); return Token(TokenType::BITWISE_AND, "&", tokenLine, tokenColumn);
+            case '|': advance(); return Token(TokenType::BITWISE_OR, "|", tokenLine, tokenColumn);
+            case '^': advance(); return Token(TokenType::BITWISE_XOR, "^", tokenLine, tokenColumn);
+            case '~': advance(); return Token(TokenType::BITWISE_INVERT, "~", tokenLine, tokenColumn);
+            
+            // Delimiters and punctuation
             case ';': advance(); return Token(TokenType::SEMICOLON, ";", tokenLine, tokenColumn);
             case ',': advance(); return Token(TokenType::COMMA, ",", tokenLine, tokenColumn);
             case '.': advance(); return Token(TokenType::DOT, ".", tokenLine, tokenColumn);
             case ':': advance(); return Token(TokenType::COLON, ":", tokenLine, tokenColumn);
+            
+            // Brackets and parentheses
             case '(': advance(); return Token(TokenType::LEFT_PAREN, "(", tokenLine, tokenColumn);
             case ')': advance(); return Token(TokenType::RIGHT_PAREN, ")", tokenLine, tokenColumn);
             case '{': advance(); return Token(TokenType::LEFT_BRACE, "{", tokenLine, tokenColumn);
@@ -218,33 +323,85 @@ Token Lexer::nextToken() {
             case '[': advance(); return Token(TokenType::LEFT_BRACKET, "[", tokenLine, tokenColumn);
             case ']': advance(); return Token(TokenType::RIGHT_BRACKET, "]", tokenLine, tokenColumn);
             
+            // Invalid character handling
             default:
-                error("Unexpected character: " + std::string(1, currentChar));
-                advance();
-                return Token(TokenType::INVALID, std::string(1, currentChar), tokenLine, tokenColumn);
+                std::string invalidChar(1, currentChar);
+                advance(); // Skip the invalid character for recovery
+                error("Unexpected character: '" + invalidChar + "' (0x" + 
+                      std::to_string(static_cast<unsigned char>(invalidChar[0])) + ")");
+                return Token(TokenType::INVALID, invalidChar, tokenLine, tokenColumn);
         }
     }
     
+    // End of file token
     return Token(TokenType::EOF_TOKEN, "", line, column);
 }
 
 std::vector<Token> Lexer::tokenize() {
     std::vector<Token> tokens;
+    tokens.reserve(source.length() / 6); // Rough estimate for performance
     
-    Token token = nextToken();
-    while (token.type != TokenType::EOF_TOKEN) {
-        if (token.type != TokenType::NEWLINE) { // Skip newlines for now
-            tokens.push_back(token);
+    try {
+        Token token = nextToken();
+        while (token.type != TokenType::EOF_TOKEN) {
+            // we might want to keep certain tokens
+            // that are typically filtered out in traditional compilation
+            if (token.type != TokenType::WHITESPACE) { // Keep newlines
+                tokens.push_back(std::move(token));
+            }
+            token = nextToken();
         }
-        token = nextToken();
+        tokens.push_back(std::move(token)); // Add EOF token
+        
+    } catch (const std::exception& e) {
+        // continue tokenization if possible
+        std::cerr << "Tokenization warning: " << e.what() << std::endl;
+        std::cerr << "Attempting to continue tokenization..." << std::endl;
+        
+        // Skip problematic character and continue
+        if (currentChar != '\0') {
+            advance();
+            // Recursively continue tokenization
+            auto remainingTokens = tokenize();
+            tokens.insert(tokens.end(), remainingTokens.begin(), remainingTokens.end());
+        }
     }
-    tokens.push_back(token); // Add EOF token
+    
+    // Optimization: shrink to fit for memory efficiency in JIT
+    tokens.shrink_to_fit();
     
     return tokens;
 }
 
 void Lexer::error(const std::string& message) {
+    // Enhanced error reporting
+    std::string context = "";
+    
+    // Extract context around the error position
+    size_t contextStart = position >= 20 ? position - 20 : 0;
+    size_t contextEnd = position + 20 < source.length() ? position + 20 : source.length();
+    
+    if (contextStart < contextEnd) {
+        context = source.substr(contextStart, contextEnd - contextStart);
+        // Replace control characters for better display
+        for (char& c : context) {
+            if (c == '\n') c = '↵';
+            else if (c == '\t') c = '→';
+        }
+    }
+    
     std::cerr << "Lexer Error at " << line << ":" << column << " - " << message << std::endl;
+    if (!context.empty()) {
+        std::cerr << "Context: ..." << context << "..." << std::endl;
+        std::cerr << "         ";
+        for (size_t i = 0; i < (position - contextStart) + 3; ++i) {
+            std::cerr << " ";
+        }
+        std::cerr << "^" << std::endl;
+    }
+    
+    // we want to continue processing when possible
+    // instead of throwing immediately
     throw std::runtime_error("Lexer error: " + message);
 }
 

--- a/compiler/semantic/CMakeLists.txt
+++ b/compiler/semantic/CMakeLists.txt
@@ -3,16 +3,15 @@
 
 # Collect all semantic source files
 set(SEMANTIC_SOURCES
-    semantic.cpp
+    semantic_core.cpp
+    semantic_error.cpp
     analyzer.cpp
     type_checker.cpp
     symbol_table.cpp
-    semantic_error.cpp
 )
 
 # Collect all semantic header files
 set(SEMANTIC_HEADERS
-    ${CMAKE_SOURCE_DIR}/include/semantic/semantic.h
     ${CMAKE_SOURCE_DIR}/include/semantic/analyzer.h
     ${CMAKE_SOURCE_DIR}/include/semantic/type_checker.h
     ${CMAKE_SOURCE_DIR}/include/semantic/symbol_table.h
@@ -40,9 +39,6 @@ target_compile_definitions(emlang_semantic PRIVATE EMLANG_EXPORTS)
 # Compiler-specific settings
 if(MSVC)
     target_compile_options(emlang_semantic PRIVATE 
-        /W4 
-        /WX- 
-        /wd4996  # Disable deprecation warnings
         /wd4251  # Disable DLL interface warnings
     )
     target_compile_definitions(emlang_semantic PRIVATE

--- a/emlang.rc
+++ b/emlang.rc
@@ -23,7 +23,7 @@ BEGIN
             VALUE "LegalCopyright",    EMLANG_COPYRIGHT "\0"
             VALUE "OriginalFilename",  "emlang.exe\0"
             VALUE "ProductName",       "EMLang Compiler\0"
-            VALUE "ProductVersion",    "0\0"
+            VALUE "ProductVersion",    "1.0.0-alpha.3 (25f737f)\0"
             VALUE "Comments",          EMLANG_COMMENTS "\0"
         END
     END

--- a/include/ast/ast_base.h
+++ b/include/ast/ast_base.h
@@ -29,32 +29,47 @@ using ExpressionPtr = std::unique_ptr<Expression>;
 using StatementPtr = std::unique_ptr<Statement>;
 
 /**
- * @enum ASTNodeType
+ * @enum NodeType
  * @brief Enumeration of all AST node types for runtime type identification
  */
-enum class ASTNodeType {
+enum class NodeType {
     // Base types
-    PROGRAM,
+    PROGRAM,         // Root node representing the entire program
     
-    // Expression types
-    LITERAL,
-    IDENTIFIER,
-    BINARY_OP,
-    UNARY_OP,
-    ASSIGNMENT,
-    FUNCTION_CALL,
-    DEREFERENCE,
-    ADDRESS_OF,
+    // Expression
+    LITERAL_EXPR,    // Literal values (numbers, strings, booleans, etc.)
+    IDENTIFIER_EXPR, // Identifier references (variables, functions)
+    BINARY_EXPR,     // Binary operations (e.g., addition, subtraction)
+    UNARY_EXPR,      // Unary operations (e.g., negation, logical NOT)    
+    ASSIGNMENT_EXPR, // Assignment (x = expr)
+    FUNCTION_CALL,   // Function call expressions (func(args))
+    MEMBER_EXPR,     // Member access (obj.member)
+#ifdef EMLANG_FEATURE_CASTING
+    CAST_EXPR,       // Type casting (cast<type>(expr) or foo as <type>)
+#endif
+    INDEX_EXPR,      // Array indexing (arr[index])
+    ARRAY_EXPR,      // Array literals ([1, 2, 3])
+    OBJECT_EXPR,     // Object literals ({key: value})
+#ifdef EMLANG_FEATURE_POINTERS
+    DEREFERENCE,     // Dereference operator (*ptr)
+    ADDRESS_OF,      // Address-of operator (&var)
+#endif
     
-    // Statement types
-    VARIABLE_DECLARATION,
-    FUNCTION_DECLARATION,
-    EXTERN_FUNCTION_DECLARATION,
-    BLOCK_STATEMENT,
-    IF_STATEMENT,
-    WHILE_STATEMENT,
-    RETURN_STATEMENT,
-    EXPRESSION_STMT
+    // Statement
+    IF_STMT,
+    WHILE_STMT,
+    FOR_STMT,
+    RETURN_STMT,
+    BLOCK_STMT,
+    EXPRESSION_STMT,
+
+    // Declarations
+    VARIABLE_DECL,
+    FUNCTION_DECL,
+    EXTERN_FN_DECL,
+#ifdef EMLANG_FEATURE_IMPORTS
+    IMPORT_DECL,      // Import declaration (DO NOT IMPLEMENT YET)
+#endif
 };
 
 /**
@@ -62,10 +77,11 @@ enum class ASTNodeType {
  * @brief Types of literal values supported by the language
  */
 enum class LiteralType {
-    NUMBER,         // Numeric literals (42, 3.14)
-    STRING,         // String literals ("hello")
+    INT,            // Integer literals (42)
+    FLOAT,          // Floating-point literals (3.14)
+    STR,            // String literals ("hello")
     CHAR,           // Character literals ('c')
-    BOOLEAN,        // Boolean literals (true, false)
+    BOOL,           // Boolean literals (true, false)
     NULL_LITERAL    // Null literal
 };
 
@@ -86,11 +102,11 @@ struct Parameter {
  */
 class EMLANG_API ASTNode {
 public:
-    ASTNodeType type;    // Runtime type identification
-    size_t line;         // Source code line number (1-based)
-    size_t column;       // Source code column number (1-based)
+    NodeType type;     // Runtime type identification
+    size_t line;       // Source code line number (1-based)
+    size_t column;     // Source code column number (1-based)
     
-    ASTNode(ASTNodeType type, size_t line = 0, size_t column = 0);
+    ASTNode(NodeType type, size_t line = 0, size_t column = 0);
     virtual ~ASTNode() = default;
     
     virtual std::string toString() const = 0;
@@ -103,7 +119,7 @@ public:
  */
 class EMLANG_API Expression : public ASTNode {
 public:
-    Expression(ASTNodeType type, size_t line = 0, size_t column = 0);
+    Expression(NodeType type, size_t line = 0, size_t column = 0);
     virtual ~Expression() = default;
 };
 
@@ -113,7 +129,7 @@ public:
  */
 class EMLANG_API Statement : public ASTNode {
 public:
-    Statement(ASTNodeType type, size_t line = 0, size_t column = 0);
+    Statement(NodeType type, size_t line = 0, size_t column = 0);
     virtual ~Statement() = default;
 };
 

--- a/include/ast/decl.h
+++ b/include/ast/decl.h
@@ -14,6 +14,7 @@
 
 #include "ast_base.h"
 #include "visitor.h"
+#include <optional>
 
 namespace emlang {
 
@@ -23,12 +24,17 @@ namespace emlang {
  */
 class EMLANG_API VariableDecl : public Statement {
 public:
-    std::string name;           // Variable name
-    std::string type;           // Variable type (optional)
-    ExpressionPtr initializer;  // Optional initializer expression
-    bool isConstant;            // true for const, false for let
+    std::string name;                // Variable name
+    std::optional<std::string> type; // Variable type (optional)
+    ExpressionPtr initializer;       // Optional initializer expression
+    bool isConstant;                 // true for const, false for let
     
-    VariableDecl(const std::string& name, const std::string& type, ExpressionPtr init = nullptr, bool isConst = false, size_t line = 0, size_t column = 0);
+    VariableDecl(
+        const std::string& name, 
+        const std::string& type, 
+        ExpressionPtr init = nullptr, 
+        bool isConst = false, 
+        size_t line = 0, size_t column = 0);
     
     // Delete copy constructor and assignment operator
     VariableDecl(const VariableDecl&) = delete;
@@ -45,15 +51,28 @@ public:
 /**
  * @class FunctionDeclaration
  * @brief Represents function declarations
+ * IMPLEMENT: FunctionDecl -> FnDecl, combine with extern function decl
  */
 class EMLANG_API FunctionDecl : public Statement {
 public:
-    std::string name;                   // Function name
-    std::vector<Parameter> parameters;  // Function parameters
-    std::string returnType;             // Return type (optional)
-    StatementPtr body;                  // Function body
+    std::string name;                      // Function name
+    std::vector<Parameter> parameters;     // Function parameters
+    std::optional<std::string> returnType; // Return type (optional)
+    StatementPtr body;                     // Function body
+    bool isExtern;                         // true if this is an extern function declaration
+    bool isAsync;                          // true if this is an async function declaration
+    bool isUnsafe;                         // true if this is an unsafe function declaration
+    std::optional<std::string> abi;        // ABI name for the function (optional)
     
-    FunctionDecl(const std::string& name, std::vector<Parameter> params, const std::string& retType, StatementPtr body, size_t line = 0, size_t column = 0);
+    FunctionDecl(
+        const std::string& name, 
+        std::vector<Parameter> params, 
+        const std::string& retType, 
+        StatementPtr body, 
+        bool isExtern = false, 
+        bool isAsync = false, 
+        bool isUnsafe = false, 
+        size_t line = 0, size_t column = 0);
     
     // Delete copy constructor and assignment operator
     FunctionDecl(const FunctionDecl&) = delete;

--- a/include/ast/dumper.h
+++ b/include/ast/dumper.h
@@ -27,27 +27,40 @@ public:
     virtual ~ASTDumper() = default;
 
     /// Dump an AST node to stdout with colored output
-    void dump(const ASTNode& node);
-
+    void dump(const ASTNode& node);    
+    
     // Visitor interface implementation - matches visitor.h exactly
     void visit(Program& node) override;
     
+    // Expression visitors
     void visit(LiteralExpr& node) override;
     void visit(IdentifierExpr& node) override;
     void visit(BinaryOpExpr& node) override;
     void visit(UnaryOpExpr& node) override;
     void visit(AssignmentExpr& node) override;
     void visit(FunctionCallExpr& node) override;
+    void visit(MemberExpr& node) override;
+#ifdef EMLANG_FEATURE_CASTING
+    void visit(CastExpr& node) override;
+#endif // EMLANG_FEATURE_CASTING
+    void visit(IndexExpr& node) override;
+    void visit(ArrayExpr& node) override;
+    void visit(ObjectExpr& node) override;
+#ifdef EMLANG_FEATURE_POINTERS
     void visit(DereferenceExpr& node) override;
     void visit(AddressOfExpr& node) override;
+#endif
 
+    // Declaration visitors
     void visit(VariableDecl& node) override;
     void visit(FunctionDecl& node) override;
     void visit(ExternFunctionDecl& node) override;
     
+    // Statement visitors
     void visit(BlockStmt& node) override;
     void visit(IfStmt& node) override;
     void visit(WhileStmt& node) override;
+    void visit(ForStmt& node) override;
     void visit(ReturnStmt& node) override;
     void visit(ExpressionStmt& node) override;
 

--- a/include/ast/stmt.h
+++ b/include/ast/stmt.h
@@ -87,6 +87,31 @@ public:
 };
 
 /**
+ * @class ForStatement
+ * @brief Represents for loop statements
+ */
+class EMLANG_API ForStmt : public Statement {
+public:
+    StatementPtr initializer;   // Loop initialization (optional)
+    ExpressionPtr condition;    // Loop condition (optional)
+    ExpressionPtr increment;    // Loop increment (optional)
+    StatementPtr body;          // Loop body
+    
+    ForStmt(StatementPtr init, ExpressionPtr cond, ExpressionPtr incr, StatementPtr body, size_t line = 0, size_t column = 0);
+    
+    // Delete copy constructor and assignment operator
+    ForStmt(const ForStmt&) = delete;
+    ForStmt& operator=(const ForStmt&) = delete;
+    
+    // Enable move constructor and assignment operator
+    ForStmt(ForStmt&&) = default;
+    ForStmt& operator=(ForStmt&&) = default;
+    
+    std::string toString() const override;
+    void accept(ASTVisitor& visitor) override;
+};
+
+/**
  * @class ReturnStatement
  * @brief Represents return statements
  */

--- a/include/ast/visitor.h
+++ b/include/ast/visitor.h
@@ -26,12 +26,18 @@ class AssignmentExpr;
 class FunctionCallExpr;
 class DereferenceExpr;
 class AddressOfExpr;
+class MemberExpr;
+class CastExpr;
+class IndexExpr;
+class ArrayExpr;
+class ObjectExpr;
 class VariableDecl;
 class FunctionDecl;
 class ExternFunctionDecl;
 class BlockStmt;
 class IfStmt;
 class WhileStmt;
+class ForStmt;
 class ReturnStmt;
 class ExpressionStmt;
 
@@ -51,22 +57,35 @@ public:
     // Visit methods for all AST node types
     virtual void visit(Program& node) = 0;
 
+    // Expression visitors
     virtual void visit(LiteralExpr& node) = 0;
     virtual void visit(IdentifierExpr& node) = 0;
     virtual void visit(BinaryOpExpr& node) = 0;
     virtual void visit(UnaryOpExpr& node) = 0;
     virtual void visit(AssignmentExpr& node) = 0;
     virtual void visit(FunctionCallExpr& node) = 0;
+    virtual void visit(MemberExpr& node) = 0;
+#ifdef EMLANG_FEATURE_CASTING
+    virtual void visit(CastExpr& node) = 0;
+#endif
+    virtual void visit(IndexExpr& node) = 0;
+    virtual void visit(ArrayExpr& node) = 0;
+    virtual void visit(ObjectExpr& node) = 0;
+#ifdef EMLANG_FEATURE_POINTERS
     virtual void visit(DereferenceExpr& node) = 0;
     virtual void visit(AddressOfExpr& node) = 0;
+#endif
 
+    // Declaration visitors
     virtual void visit(VariableDecl& node) = 0;
     virtual void visit(FunctionDecl& node) = 0;
     virtual void visit(ExternFunctionDecl& node) = 0;
     
+    // Statement visitors
     virtual void visit(BlockStmt& node) = 0;
     virtual void visit(IfStmt& node) = 0;
     virtual void visit(WhileStmt& node) = 0;
+    virtual void visit(ForStmt& node) = 0;
     virtual void visit(ReturnStmt& node) = 0;
     virtual void visit(ExpressionStmt& node) = 0;
 };

--- a/include/codegen/builtins_integration.h
+++ b/include/codegen/builtins_integration.h
@@ -1,0 +1,179 @@
+//===--- builtins_integration.h - Builtins Integration --------*- C++ -*-===//
+//
+// Part of the EMLang Project, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Integration with existing builtins.h/cpp system for advanced JIT
+//
+// This file provides integration interface between the modular codegen system 
+// and the existing builtin functions infrastructure, enabling seamless symbol
+// resolution and runtime binding for both AOT and JIT compilation.
+//===----------------------------------------------------------------------===//
+
+#ifndef EMLANG_BUILTINS_INTEGRATION_H
+#define EMLANG_BUILTINS_INTEGRATION_H
+
+#pragma once
+#include <emlang_export.h>
+#include <string>
+#include <vector>
+
+#ifdef EMLANG_ORCJIT_ENABLED
+// Forward declarations for LLVM types
+namespace llvm {
+    class Error;
+    class Type;
+    class LLVMContext;
+}
+#endif
+
+namespace emlang {
+
+// Forward declarations
+class JITEngine;
+class SymbolResolver;
+class CodegenError;
+
+/**
+ * @namespace builtins
+ * @brief Builtin functions integration for codegen system
+ */
+namespace builtins {
+
+/**
+ * @brief Initialize the builtin integration system
+ * 
+ * This function must be called before any other builtin integration
+ * functions are used. It registers all builtin function implementations
+ * and prepares them for use with both AOT and JIT compilation.
+ */
+EMLANG_API void initializeBuiltinIntegration();
+
+/**
+ * @brief Get function pointer for a builtin function
+ * @param name Name of the builtin function
+ * @return Function pointer or nullptr if not found
+ */
+EMLANG_API void* getBuiltinFunctionPointer(const std::string& name);
+
+/**
+ * @brief Check if a builtin function is available
+ * @param name Name of the function to check
+ * @return true if the function is available, false otherwise
+ */
+EMLANG_API bool isBuiltinFunctionAvailable(const std::string& name);
+
+/**
+ * @brief Get list of all available builtin functions
+ * @return Vector of function names
+ */
+EMLANG_API std::vector<std::string> getAvailableBuiltinFunctions();
+
+#ifdef EMLANG_ORCJIT_ENABLED
+
+/**
+ * @brief Register all builtin functions with a JIT engine
+ * @param jitEngine JIT engine to register functions with
+ * @return Error if registration failed
+ */
+EMLANG_API llvm::Error registerBuiltinsWithJIT(JITEngine& jitEngine);
+
+/**
+ * @brief Register all builtin functions with a symbol resolver
+ * @param resolver Symbol resolver to register functions with
+ * @return Error if registration failed
+ */
+EMLANG_API llvm::Error registerBuiltinsWithResolver(SymbolResolver& resolver);
+
+/**
+ * @brief Get LLVM function type for a builtin function
+ * @param name Name of the builtin function
+ * @param context LLVM context for type creation
+ * @return LLVM function type or nullptr if not found
+ */
+EMLANG_API llvm::Type* getBuiltinFunctionType(const std::string& name, llvm::LLVMContext& context);
+
+#endif // EMLANG_ORCJIT_ENABLED
+
+} // namespace builtins
+
+/**
+ * @namespace codegen
+ * @brief Codegen-specific builtin integration
+ */
+namespace codegen {
+
+/**
+ * @class BuiltinCodegenIntegration
+ * @brief High-level integration class for codegen and builtins
+ */
+class EMLANG_API BuiltinCodegenIntegration {
+public:
+    /**
+     * @brief Initialize builtin integration for codegen
+     * @return Success or error status
+     */
+    static CodegenError initializeBuiltins();
+    
+    /**
+     * @brief Get builtin function address for AOT compilation
+     * @param name Name of the builtin function
+     * @return Function address or nullptr if not found
+     */
+    static void* getBuiltinAddress(const std::string& name);
+    
+    /**
+     * @brief Check if a symbol is a builtin function
+     * @param name Symbol name to check
+     * @return true if it's a builtin function
+     */
+    static bool isBuiltinSymbol(const std::string& name);
+    
+#ifdef EMLANG_ORCJIT_ENABLED
+    /**
+     * @brief Register all builtins with a JIT engine
+     * @param jit JIT engine instance
+     * @return Success or error status
+     */
+    static CodegenError registerWithJIT(JITEngine& jit);
+    
+    /**
+     * @brief Register all builtins with a symbol resolver
+     * @param resolver Symbol resolver instance
+     * @return Success or error status
+     */
+    static CodegenError registerWithResolver(SymbolResolver& resolver);
+#endif
+};
+
+} // namespace codegen
+
+} // namespace emlang
+
+// ======================== C API COMPATIBILITY ========================
+
+extern "C" {
+
+/**
+ * @brief C API: Initialize builtin integration
+ */
+EMLANG_API void emlang_initialize_builtin_integration();
+
+/**
+ * @brief C API: Get builtin function pointer
+ * @param name Function name (null-terminated string)
+ * @return Function pointer or NULL if not found
+ */
+EMLANG_API void* emlang_get_builtin_function_pointer(const char* name);
+
+/**
+ * @brief C API: Check if builtin function is available
+ * @param name Function name (null-terminated string)
+ * @return 1 if available, 0 otherwise
+ */
+EMLANG_API int emlang_is_builtin_function_available(const char* name);
+
+} // extern "C"
+
+#endif // EMLANG_BUILTINS_INTEGRATION_H

--- a/include/emlang.h
+++ b/include/emlang.h
@@ -6,9 +6,9 @@
 #define EMLANG_H
 
 /*------   Version   ------*/
-#define EMLANG_VERSION_MAJOR    0
-#define EMLANG_VERSION_MINOR    9
-#define EMLANG_VERSION_PATCH    26
+#define EMLANG_VERSION_MAJOR    1
+#define EMLANG_VERSION_MINOR    0
+#define EMLANG_VERSION_PATCH    0
 #define EMLANG_VERSION_NUMBER  (EMLANG_VERSION_MAJOR *100*100 + EMLANG_VERSION_MINOR *100 + EMLANG_VERSION_PATCH)
 #define EMLANG_VERSION_STRING   EMLANG_VERSION_MAJOR "." \
                                 EMLANG_VERSION_MINOR "." \
@@ -29,10 +29,10 @@
 /***************************************
 *  Feature flags
 ***************************************/
-#define EMLANG_FEATURE_EXTERN_FUNCTIONS  0
 #define EMLANG_FEATURE_POINTERS          0
-#define EMLANG_FEATURE_STRINGS           0
-#define EMLANG_FEATURE_ARRAYS            0
+#define EMLANG_FEATURE_CASTING           0
+#define EMLANG_FEATURE_IMPORTS           0
+#define EMLANG_FEATURE_EXTERN_FUNCTIONS  0
 
 
 #endif // EMLANG_H

--- a/include/emlang_export.h
+++ b/include/emlang_export.h
@@ -1,0 +1,55 @@
+//===--- emlang_export.h - Global DLL Export/Import Macros ------*- C++ -*-===//
+//
+// Part of the EMLang Project, under the Apache License v2.0 with LLVM Exceptions.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// Global DLL export/import macros for all EMLang components
+//
+// This file provides a unified DLL export/import system that should be
+// included by all EMLang header files that need to export symbols.
+//===----------------------------------------------------------------------===//
+
+#ifndef EMLANG_EXPORT_H
+#define EMLANG_EXPORT_H
+
+#pragma once
+
+// ======================== DLL Export/Import Macros ========================
+#ifdef _WIN32
+    #ifdef EMLANG_EXPORTS
+        #define EMLANG_API __declspec(dllexport)
+    #elif defined(EMLANG_DLL)
+        #define EMLANG_API __declspec(dllimport)
+    #else
+        #define EMLANG_API
+    #endif
+#else
+    // Unix/Linux platforms
+    #ifdef EMLANG_EXPORTS
+        #define EMLANG_API __attribute__((visibility("default")))
+    #else
+        #define EMLANG_API
+    #endif
+#endif
+
+// ======================== Template Export Helper ========================
+// For template classes that need explicit instantiation
+#ifdef _WIN32
+    #ifdef EMLANG_EXPORTS
+        #define EMLANG_TEMPLATE_API
+    #else
+        #define EMLANG_TEMPLATE_API extern
+    #endif
+#else
+    #define EMLANG_TEMPLATE_API
+#endif
+
+// ======================== C Export/Import Macros ========================
+#ifdef __cplusplus
+    #define EMLANG_C_API extern "C" EMLANG_API
+#else
+    #define EMLANG_C_API EMLANG_API
+#endif
+
+#endif // EMLANG_EXPORT_H

--- a/include/lexer.h
+++ b/include/lexer.h
@@ -17,6 +17,5 @@
 // Include all lexer components
 #include "lexer/token.h"
 #include "lexer/lexer_core.h"
-#include "lexer/preprocessor.h"
 
 #endif // EM_LANG_LEXER_H

--- a/include/lexer/token.h
+++ b/include/lexer/token.h
@@ -26,91 +26,100 @@ namespace emlang {
  * @brief Enumeration of all possible token types in the EMLang language
  */
 enum class TokenType {
-    // Reserved (0x00-0x0F)
-    RESERVED_BEGIN =        0x00,    // Reserved for future use
-    RESERVED_END =          0x0F,    // Reserved for future use
+    // Special (0x00-0x0F)
+    EOF_TOKEN =             0,     // End of file token
+    NEWLINE =               1,     // Newline character token
+    WHITESPACE =            2,     // Whitespace token (spaces, tabs)
+    COMMENT =               3,     // Comment token (single-line or multi-line)
+    BLOCK_COMMENT =         4,     // Block comment token (/* ... */)
+    DOC_COMMENT =           5,     // Documentation comment token (/** ... */)
 
     // Literals (0x10-0x1F)
-    NUMBER =                16,    // Numeric literal
-    STRING =                17,    // String literal
-    CHAR_LITERAL =          18,    // Character literal
-    IDENTIFIER =            19,    // Identifier (variable, function, etc.)
-    
-    // Keywords (0x20-0x3F)
-    LET =                   32,    // let variable declaration
-    CONST =                 33,    // const constant declaration
-    FUNCTION =              34,    // function declaration
-    EXTERN =                35,    // extern function declaration
-    IF =                    36,    // if conditional statement
-    ELSE =                  37,    // else conditional statement
-    WHILE =                 38,    // while loop statement
-    FOR =                   39,    // for loop statement
-    RETURN =                40,    // return statement
-    TRUE =                  41,    // true boolean literal
-    FALSE =                 42,    // false boolean literal
-    NULL_TOKEN =            43,    // null literal
+    INT =                   16,    // Integer literal
+    FLOAT =                 17,    // Floating point literal
+    CHAR =                  18,    // Character literal
+    STR =                   19,    // String literal
+    BOOL =                  20,    // Boolean literal (true/false)
+    ARRAY =                 21,    // Array literal
+    NULL_LITERAL =          22,    // Null literal
 
-    // C-style primitive type keywords (0x40-0x5F)
-    INT8 =                  64,    // int8 signed 8-bit integer
-    INT16 =                 65,    // int16 signed 16-bit integer  
-    INT32 =                 66,    // int32 signed 32-bit integer
-    INT64 =                 67,    // int64 signed 64-bit integer
-    ISIZE =                 68,    // isize pointer-sized signed integer
-    UINT8 =                 69,    // uint8 unsigned 8-bit integer
-    UINT16 =                70,    // uint16 unsigned 16-bit integer
-    UINT32 =                71,    // uint32 unsigned 32-bit integer
-    UINT64 =                72,    // uint64 unsigned 64-bit integer
-    USIZE =                 73,    // usize pointer-sized unsigned integer
-    FLOAT =                 74,    // float 32-bit floating point
-    DOUBLE =                75,    // double 64-bit floating point
-    CHAR =                  76,    // char Unicode scalar value
-    STR =                   77,    // str string slice
-    BOOL =                  78,    // bool boolean type
+    // Keywords (0x20-0x4F)
+    IDENTIFIER =            32,    // Identifier (variable, function, etc.)
+    LET =                   33,    // let variable declaration
+    CONST =                 34,    // const constant declaration
+    FUNCTION =              35,    // function declaration
+    EXTERN =                36,    // extern function declaration
+    IF =                    37,    // if conditional statement
+    ELSE =                  38,    // else conditional statement
+    WHILE =                 39,    // while loop statement
+    FOR =                   40,    // for loop statement
+    RETURN =                41,    // return statement
 
-    // Operators (0x60-0x7F)
-    PLUS =                  96,    // + addition operator
-    MINUS =                 97,    // - subtraction operator
-    MULTIPLY =              98,    // * multiplication operator
-    DIVIDE =                99,    // / division operator
-    MODULO =                100,   // % modulo operator
-    ASSIGN =                101,   // = assignment operator
-    EQUAL =                 102,   // == equality operator
-    NOT_EQUAL =             103,   // != inequality operator
-    LESS_THAN =             104,   // < relational operator
-    GREATER_THAN =          105,   // > relational operator
-    LESS_EQUAL =            106,   // <= relational operator
-    GREATER_EQUAL =         107,   // >= relational operator
-    LOGICAL_AND =           108,   // && logical conjunction
-    LOGICAL_OR =            109,   // || logical disjunction
-    LOGICAL_NOT =           110,   // ! logical negation
-    AMPERSAND =             111,   // & address-of operator
+    // Operators (0x50-0x6F)
+    PLUS =                  80,    // + addition operator
+    MINUS =                 81,    // - subtraction operator
+    MULTIPLY =              82,    // * multiplication operator
+    DIVIDE =                83,    // / division operator
+    MODULO =                84,    // % modulo operator
+    ASSIGN =                85,    // = assignment operator
+    EQUAL =                 86,    // == equality operator
+    NOT_EQUAL =             87,    // != inequality operator
+    LESS_THAN =             88,    // < relational operator
+    GREATER_THAN =          89,    // > relational operator
+    LESS_EQUAL =            90,    // <= relational operator
+    GREATER_EQUAL =         91,    // >= relational operator
+    LEFT_SHIFT =            92,    // << left shift operator
+    RIGHT_SHIFT =           93,    // >> right shift operator
+    LOGICAL_AND =           94,    // && logical conjunction
+    LOGICAL_OR =            95,    // || logical disjunction
+    LOGICAL_NOT =           96,    // ! logical negation
+    BITWISE_AND =           97,    // & bitwise AND operator
+    BITWISE_OR =            98,    // | bitwise OR operator
+    BITWISE_XOR =           99,    // ^ bitwise XOR operator
+    BITWISE_INVERT =        100,   // ~ bitwise INVERSION operator
+#ifdef EMLANG_ENABLE_POINTERS
+    AMPERSAND =             101,   // & address-of operator
+#endif
     
-    // Delimiters (0x80-0x8F)
-    SEMICOLON =             128,   // ; statement terminator
-    COMMA =                 129,   // , argument separator
-    DOT =                   130,   // . member access operator
-    COLON =                 131,   // : type annotation or label
+    // Delimiters (0x70-0x8F)
+    SEMICOLON =             112,   // ; statement terminator
+    COMMA =                 113,   // , argument separator
+    DOT =                   114,   // . member access operator
+    COLON =                 115,   // : type annotation or label
+    LEFT_PAREN =            116,   // ( left parenthesis
+    RIGHT_PAREN =           117,   // ) right parenthesis
+    LEFT_BRACE =            118,   // { left brace
+    RIGHT_BRACE =           119,   // } right brace
+    LEFT_BRACKET =          120,   // [ left bracket
+    RIGHT_BRACKET =         121,   // ] right bracket
     
-    // Brackets (0x90-0x9F)
-    LEFT_PAREN =            144,   // ( left parenthesis
-    RIGHT_PAREN =           145,   // ) right parenthesis
-    LEFT_BRACE =            146,   // { left brace
-    RIGHT_BRACE =           147,   // } right brace
-    LEFT_BRACKET =          148,   // [ left bracket
-    RIGHT_BRACKET =         149,   // ] right bracket
-    
-    // Special (0xA0-0xAF)
-    NEWLINE =               160,    // Newline character
-    EOF_TOKEN =             161,    // End of file token    
+    // Reserved (0x8F-0xFE)
+    RESERVED_START =        0x8F,   // Start of reserved range
+    RESERVED_END =          0xFE,   // End of reserved range
     
     // INVALID Token for special cases
     INVALID =               0xFF,   // Used for lexical errors and unknown characters
 };
 
 static const std::map<TokenType, std::string> tokenNames = {
-    {TokenType::NUMBER, "NUMBER"},
-    {TokenType::STRING, "STRING"},
-    {TokenType::CHAR_LITERAL, "CHAR_LITERAL"},
+    /// Special
+    {TokenType::EOF_TOKEN, "EOF"},
+    {TokenType::NEWLINE, "NEWLINE"},
+    {TokenType::WHITESPACE, "WHITESPACE"},
+    {TokenType::COMMENT, "COMMENT"},
+    {TokenType::BLOCK_COMMENT, "BLOCK_COMMENT"},
+    {TokenType::DOC_COMMENT, "DOC_COMMENT"},
+
+    /// Literals
+    {TokenType::INT, "INT"},
+    {TokenType::FLOAT, "FLOAT"},
+    {TokenType::CHAR, "CHAR"},
+    {TokenType::STR, "STR"},
+    {TokenType::BOOL, "BOOL"},
+    {TokenType::ARRAY, "ARRAY"},
+    {TokenType::NULL_LITERAL, "NULL"},
+
+    /// Keywords
     {TokenType::IDENTIFIER, "IDENTIFIER"},
     {TokenType::LET, "LET"},
     {TokenType::CONST, "CONST"},
@@ -121,27 +130,8 @@ static const std::map<TokenType, std::string> tokenNames = {
     {TokenType::WHILE, "WHILE"},
     {TokenType::FOR, "FOR"},
     {TokenType::RETURN, "RETURN"},
-    {TokenType::TRUE, "TRUE"},
-    {TokenType::FALSE, "FALSE"},
-    {TokenType::NULL_TOKEN, "NULL"},
-
-    // C-style primitive type tokens
-    {TokenType::INT8, "INT8"},
-    {TokenType::INT16, "INT16"},
-    {TokenType::INT32, "INT32"},
-    {TokenType::INT64, "INT64"},
-    {TokenType::ISIZE, "ISIZE"},
-    {TokenType::UINT8, "UINT8"},
-    {TokenType::UINT16, "UINT16"},
-    {TokenType::UINT32, "UINT32"},
-    {TokenType::UINT64, "UINT64"},
-    {TokenType::USIZE, "USIZE"},
-    {TokenType::FLOAT, "FLOAT"},
-    {TokenType::DOUBLE, "DOUBLE"},
-    {TokenType::CHAR, "CHAR"},
-    {TokenType::STR, "STR"},
-    {TokenType::BOOL, "BOOL"},
     
+    /// Operators
     {TokenType::PLUS, "PLUS"},
     {TokenType::MINUS, "MINUS"},
     {TokenType::MULTIPLY, "MULTIPLY"},
@@ -154,10 +144,20 @@ static const std::map<TokenType, std::string> tokenNames = {
     {TokenType::GREATER_THAN, "GREATER_THAN"},
     {TokenType::LESS_EQUAL, "LESS_EQUAL"},
     {TokenType::GREATER_EQUAL, "GREATER_EQUAL"},
+    {TokenType::LEFT_SHIFT, "LEFT_SHIFT"},
+    {TokenType::RIGHT_SHIFT, "RIGHT_SHIFT"},
     {TokenType::LOGICAL_AND, "LOGICAL_AND"},
     {TokenType::LOGICAL_OR, "LOGICAL_OR"},
     {TokenType::LOGICAL_NOT, "LOGICAL_NOT"},
+    {TokenType::BITWISE_AND, "BITWISE_AND"},
+    {TokenType::BITWISE_OR, "BITWISE_OR"},
+    {TokenType::BITWISE_XOR, "BITWISE_XOR"},
+    {TokenType::BITWISE_INVERT, "BITWISE_IVERT"},
+#ifdef EMLANG_ENABLE_POINTERS
     {TokenType::AMPERSAND, "AMPERSAND"},
+#endif
+
+    /// Delimiters
     {TokenType::SEMICOLON, "SEMICOLON"},
     {TokenType::COMMA, "COMMA"},
     {TokenType::DOT, "DOT"},
@@ -168,9 +168,9 @@ static const std::map<TokenType, std::string> tokenNames = {
     {TokenType::RIGHT_BRACE, "RIGHT_BRACE"},
     {TokenType::LEFT_BRACKET, "LEFT_BRACKET"},
     {TokenType::RIGHT_BRACKET, "RIGHT_BRACKET"},
-    {TokenType::NEWLINE, "NEWLINE"},
-    {TokenType::EOF_TOKEN, "EOF"},
+
     {TokenType::INVALID, "INVALID"}
+    
 };
 
 static const std::map<std::string, TokenType> keywords = {
@@ -183,25 +183,14 @@ static const std::map<std::string, TokenType> keywords = {
     {"while", TokenType::WHILE},
     {"for", TokenType::FOR},
     {"return", TokenType::RETURN},
-    {"true", TokenType::TRUE},
-    {"false", TokenType::FALSE},
-    {"null", TokenType::NULL_TOKEN},
-    // C-style primitive type keywords
-    {"int8", TokenType::INT8},
-    {"int16", TokenType::INT16},
-    {"int32", TokenType::INT32},
-    {"int64", TokenType::INT64},
-    {"isize", TokenType::ISIZE},
-    {"uint8", TokenType::UINT8},
-    {"uint16", TokenType::UINT16},
-    {"uint32", TokenType::UINT32},
-    {"uint64", TokenType::UINT64},
-    {"usize", TokenType::USIZE},
+    
+    {"int", TokenType::INT},
     {"float", TokenType::FLOAT},
-    {"double", TokenType::DOUBLE},
     {"char", TokenType::CHAR},
     {"str", TokenType::STR},
-    {"bool", TokenType::BOOL}
+    {"bool", TokenType::BOOL},
+    {"array", TokenType::ARRAY},
+    {"null", TokenType::NULL_LITERAL},
 };
 
 /**

--- a/include/parser/parser.h
+++ b/include/parser/parser.h
@@ -579,6 +579,21 @@ private:
     std::string parseType();
     
     /**
+     * @brief Converts a Token to BinaryOpExpr::BinOp enum
+     * @param token The token to convert
+     * @return BinaryOpExpr::BinOp enum value corresponding to the token
+     * 
+     * This helper method maps TokenType values to their corresponding
+     * BinaryOpExpr::BinOp enum values for creating binary expression nodes.
+     * 
+     * Supported mappings:
+     * - Arithmetic: +, -, *, /, %
+     * - Bitwise: &, |, ^, ~, <<, >>
+     * - Comparison: ==, !=, <, <=, >, >=
+     * - Logical: &&, ||, !
+     */
+    BinaryOpExpr::BinOp tokenToBinOp(const Token& token);
+    /**
      * @brief Parses pointer type annotations
      * @return String representing the parsed pointer type
      * 
@@ -593,6 +608,174 @@ private:
      * Handles multiple levels of indirection and validates pointer syntax.
      */
     std::string parsePointerType();
+                                       
+    /**
+     * @brief Parses member access expressions (obj.member, obj.method())
+     * @return ExpressionPtr to MemberExpression AST node
+     * 
+     * Handles member access syntax:
+     * ```
+     * object.field
+     * object.method()
+     * object.field.nested
+     * ```
+     * 
+     * The method:
+     * - Parses the object expression
+     * - Handles dot notation for member access
+     * - Distinguishes between field access and method calls
+     * - Supports chained member access
+     */
+    ExpressionPtr parseMemberAccess(ExpressionPtr object);
+    
+    /**
+     * @brief Parses array/object indexing expressions (arr[index])
+     * @return ExpressionPtr to IndexExpression AST node
+     * 
+     * Handles indexing syntax:
+     * ```
+     * array[index]
+     * map[key]
+     * matrix[row][col]  // chained indexing
+     * ```
+     * 
+     * The method:
+     * - Parses the array/object expression
+     * - Parses the index expression within brackets
+     * - Supports chained indexing operations
+     * - Validates bracket matching
+     */
+    ExpressionPtr parseIndexAccess(ExpressionPtr array);
+    
+#ifdef EMLANG_FEATURE_CASTING
+    /**
+     * @brief Parses type casting expressions (expr as Type)
+     * @return ExpressionPtr to CastExpression AST node
+     * 
+     * Handles casting syntax:
+     * ```
+     * expression as TargetType
+     * value as int32
+     * pointer as void*
+     * ```
+     * 
+     * The method:
+     * - Parses the source expression
+     * - Parses the target type after 'as' keyword
+     * - Creates appropriate cast expression
+     * - Handles both safe and unsafe casts
+     */
+    ExpressionPtr parseCastExpression(ExpressionPtr operand);
+#endif // EMLANG_FEATURE_CASTING
+    
+    /**
+     * @brief Parses array literal expressions ([elem1, elem2, ...])
+     * @return ExpressionPtr to ArrayExpression AST node
+     * 
+     * Handles array literal syntax:
+     * ```
+     * []                    // empty array
+     * [1, 2, 3]            // numeric array
+     * ["a", "b", "c"]      // string array
+     * [expr1, expr2, ...]  // expression array
+     * ```
+     * 
+     * The method:
+     * - Parses opening bracket
+     * - Parses comma-separated list of expressions
+     * - Handles trailing commas (optional)
+     * - Creates ArrayExpression AST node
+     */
+    ExpressionPtr parseArrayLiteral();
+    
+    /**
+     * @brief Parses object literal expressions ({key: value, ...})
+     * @return ExpressionPtr to ObjectExpression AST node
+     * 
+     * Handles object literal syntax:
+     * ```
+     * {}                        // empty object
+     * {key: value}             // single field
+     * {key1: value1, key2: value2}  // multiple fields
+     * {name: "John", age: 30}  // mixed types
+     * ```
+     * 
+     * The method:
+     * - Parses opening brace
+     * - Parses comma-separated key-value pairs
+     * - Handles string and identifier keys
+     * - Supports trailing commas
+     * - Creates ObjectExpression AST node
+     */
+    ExpressionPtr parseObjectLiteral();
+    
+    /**
+     * @brief Parses assignment expressions with various operators
+     * @return ExpressionPtr to AssignmentExpression AST node
+     * 
+     * Handles assignment syntax:
+     * ```
+     * variable = value
+     * array[index] = value
+     * object.field = value
+     * variable += value    // compound assignment
+     * variable -= value
+     * variable *= value
+     * variable /= value
+     * ```
+     * 
+     * The method:
+     * - Parses left-hand side (lvalue)
+     * - Identifies assignment operator type
+     * - Parses right-hand side (rvalue)
+     * - Validates assignment target
+     * - Creates AssignmentExpression AST node
+     */
+    ExpressionPtr parseAssignmentExpression();
+    
+    // ======================== OPTIMIZATION HELPERS ========================
+    
+    /**
+     * @brief Optimizes constant expressions at parse time
+     * @param expr Expression to potentially optimize
+     * @return Optimized expression or original if no optimization possible
+     * 
+     * Performs compile-time constant folding:
+     * ```
+     * 2 + 3 * 4    => 14
+     * true && false => false
+     * "hello" + " world" => "hello world"
+     * ```
+     * 
+     * Early optimization reduces AST size and improves performance.
+     */
+    ExpressionPtr optimizeConstantExpression(ExpressionPtr expr);
+    
+    /**
+     * @brief Checks if an expression can be evaluated at compile time
+     * @param expr Expression to check
+     * @return true if expression is constant, false otherwise
+     * 
+     * Determines if an expression consists only of:
+     * - Literal values
+     * - Constant operations
+     * - Compile-time known values
+     */
+    bool isConstantExpression(const ExpressionPtr& expr);
+    
+    /**
+     * @brief Validates operator precedence and associativity
+     * @param leftExpr Left operand expression
+     * @param rightExpr Right operand expression  
+     * @param op Operator between expressions
+     * @return true if precedence is correct, false if parentheses needed
+     * 
+     * Helps with error reporting and suggests parentheses where
+     * operator precedence might be confusing to readers.
+     */
+    bool validateOperatorPrecedence(const ExpressionPtr& leftExpr, 
+                                   const ExpressionPtr& rightExpr, 
+                                   const std::string& op);
     
     // ======================== ERROR HANDLING METHODS ========================
     

--- a/include/semantic/semantic_core.h
+++ b/include/semantic/semantic_core.h
@@ -7,8 +7,8 @@
 // Semantic core interface for the EMLang programming language
 //===----------------------------------------------------------------------===//
 
-#ifndef EM_LANG_SEMANTIC_H
-#define EM_LANG_SEMANTIC_H
+#ifndef EM_LANG_SEMANTIC_CORE_H
+#define EM_LANG_SEMANTIC_CORE_H
 
 #pragma once
 

--- a/src/emlang_check.cpp
+++ b/src/emlang_check.cpp
@@ -19,61 +19,61 @@ private:
     }
     
 public:
-    void visit(LiteralExpression& node) override {
+    void visit(LiteralExpr& node) override {
         printIndent();
-        std::cout << "LiteralExpression: " << node.value << std::endl;
+        std::cout << "LiteralExpr: " << node.value << std::endl;
     }
     
-    void visit(IdentifierExpression& node) override {
+    void visit(IdentifierExpr& node) override {
         printIndent();
-        std::cout << "IdentifierExpression: " << node.name << std::endl;
+        std::cout << "IdentifierExpr: " << node.name << std::endl;
     }
     
-    void visit(BinaryOpExpression& node) override {
+    void visit(BinaryOpExpr& node) override {
         printIndent();
-        std::cout << "BinaryOpExpression: " << node.operator_ << std::endl;
+        std::cout << "BinaryOpExpr: " << node.operator_ << std::endl;
         indent++;
         node.left->accept(*this);
         node.right->accept(*this);
         indent--;
     }
     
-    void visit(UnaryOpExpression& node) override {
+    void visit(UnaryOpExpr& node) override {
         printIndent();
-        std::cout << "UnaryOpExpression: " << node.operator_ << std::endl;
+        std::cout << "UnaryOpExpr: " << node.operator_ << std::endl;
         indent++;
         node.operand->accept(*this);
         indent--;
     }
     
-    void visit(DereferenceExpression& node) override {
+    void visit(DereferenceExpr& node) override {
         printIndent();
-        std::cout << "DereferenceExpression: *" << std::endl;
+        std::cout << "DereferenceExpr: *" << std::endl;
         indent++;
         node.operand->accept(*this);
         indent--;
     }
     
-    void visit(AddressOfExpression& node) override {
+    void visit(AddressOfExpr& node) override {
         printIndent();
-        std::cout << "AddressOfExpression: &" << std::endl;
+        std::cout << "AddressOfExpr: &" << std::endl;
         indent++;
         node.operand->accept(*this);
         indent--;
     }
 
-    void visit(AssignmentExpression& node) override {
+    void visit(AssignmentExpr& node) override {
         printIndent();
-        std::cout << "AssignmentExpression: =" << std::endl;
+        std::cout << "AssignmentExpr: =" << std::endl;
         indent++;
         node.target->accept(*this);
         node.value->accept(*this);
         indent--;
     }
     
-    void visit(FunctionCallExpression& node) override {
+    void visit(FunctionCallExpr& node) override {
         printIndent();
-        std::cout << "FunctionCallExpression: " << node.functionName << std::endl;
+        std::cout << "FunctionCallExpr: " << node.functionName << std::endl;
         indent++;
         for (auto& arg : node.arguments) {
             arg->accept(*this);
@@ -81,9 +81,9 @@ public:
         indent--;
     }
     
-    void visit(VariableDeclaration& node) override {
+    void visit(VariableDecl& node) override {
         printIndent();
-        std::cout << "VariableDeclaration: " << (node.isConstant ? "const " : "let ") 
+        std::cout << "VariableDecl: " << (node.isConstant ? "const " : "let ") 
                   << node.name << ": " << node.type << std::endl;
         if (node.initializer) {
             indent++;
@@ -92,9 +92,9 @@ public:
         }
     }
     
-    void visit(FunctionDeclaration& node) override {
+    void visit(FunctionDecl& node) override {
         printIndent();
-        std::cout << "FunctionDeclaration: " << node.name << std::endl;
+        std::cout << "FunctionDecl: " << node.name << std::endl;
         indent++;
         for (auto& param : node.parameters) {
             printIndent();
@@ -106,9 +106,9 @@ public:
         indent--;
     }
     
-    void visit(ExternFunctionDeclaration& node) override {
+    void visit(ExternFunctionDecl& node) override {
         printIndent();
-        std::cout << "ExternFunctionDeclaration: " << node.name << std::endl;
+        std::cout << "ExternFunctionDecl: " << node.name << std::endl;
         indent++;
         for (auto& param : node.parameters) {
             printIndent();
@@ -121,9 +121,9 @@ public:
         indent--;
     }
     
-    void visit(BlockStatement& node) override {
+    void visit(BlockStmt& node) override {
         printIndent();
-        std::cout << "BlockStatement:" << std::endl;
+        std::cout << "BlockStmt:" << std::endl;
         indent++;
         for (auto& stmt : node.statements) {
             stmt->accept(*this);
@@ -131,9 +131,9 @@ public:
         indent--;
     }
     
-    void visit(IfStatement& node) override {
+    void visit(IfStmt& node) override {
         printIndent();
-        std::cout << "IfStatement:" << std::endl;
+        std::cout << "IfStmt:" << std::endl;
         indent++;
         std::cout << "Condition:" << std::endl;
         node.condition->accept(*this);
@@ -146,9 +146,9 @@ public:
         indent--;
     }
     
-    void visit(WhileStatement& node) override {
+    void visit(WhileStmt& node) override {
         printIndent();
-        std::cout << "WhileStatement:" << std::endl;
+        std::cout << "WhileStmt:" << std::endl;
         indent++;
         std::cout << "Condition:" << std::endl;
         node.condition->accept(*this);
@@ -157,9 +157,9 @@ public:
         indent--;
     }
     
-    void visit(ReturnStatement& node) override {
+    void visit(ReturnStmt& node) override {
         printIndent();
-        std::cout << "ReturnStatement:" << std::endl;
+        std::cout << "ReturnStmt:" << std::endl;
         if (node.value) {
             indent++;
             node.value->accept(*this);
@@ -167,9 +167,9 @@ public:
         }
     }
     
-    void visit(ExpressionStatement& node) override {
+    void visit(ExpressionStmt& node) override {
         printIndent();
-        std::cout << "ExpressionStatement:" << std::endl;
+        std::cout << "ExpressionStmt:" << std::endl;
         indent++;
         node.expression->accept(*this);
         indent--;
@@ -186,7 +186,7 @@ public:
 };
 
 // Token printer function
-void printTokens(const std::vector<Token>& tokens) {
+static void printTokens(const std::vector<Token>& tokens) {
     std::cout << "=== TOKENS ===" << std::endl;
     for (const auto& token : tokens) {
         std::cout << token.toString() << std::endl;
@@ -195,7 +195,7 @@ void printTokens(const std::vector<Token>& tokens) {
 }
 
 // File reading utility function
-std::string readFile(const std::string& filename) {
+static std::string readFile(const std::string& filename) {
     std::ifstream file(filename);
     if (!file.is_open()) {
         throw std::runtime_error("Could not open file: " + filename);
@@ -206,8 +206,8 @@ std::string readFile(const std::string& filename) {
     return buffer.str();
 }
 
-// Kullanım bilgilerini yazdırma
-void printUsage(const char* programName) {
+// Print usage information
+static void printUsage(const char* programName) {
     std::cout << "USAGE: " << programName << "[options] <source_file>" << std::endl;
     std::cout << "Options:" << std::endl;
     std::cout << "  --tokens               Show lexer tokens" << std::endl;
@@ -224,8 +224,8 @@ struct CheckOptions {
     bool showHelp = false;
 };
 
-// Argüman parse etme
-CheckOptions parseArguments(int argc, char* argv[]) {
+// Argument parse
+static CheckOptions parseArguments(int argc, char* argv[]) {
     CheckOptions options;
     
     for (int i = 1; i < argc; ++i) {


### PR DESCRIPTION
## What does this update aim to solve?

Fix: #6 

Reduced complexity of `parseExpression` method and simplified, dereference and address-of operators will be considered experimental. Added `parseMemberAccess` and `parseIndexAccess` methods. Types in parsePrimary method need to be updated to a more modern form since lexer token type is updated. Removed C type mapping in parseType in general. Intended to add a casting for type conversions, but this feature is experimental (not currently available).

Added optimization methods for parser, so parser can generate safer and faster subtrees.

> [!Warning]
> Using optimizations in parser may not work exactly as expected. This optimization will be optional in the future.