### PR TITLE
LLVM codegen refactoring and improvments

### DIFF
--- a/compiler/ast/expr.cpp
+++ b/compiler/ast/expr.cpp
@@ -204,4 +204,33 @@ void AddressOfExpr::accept(ASTVisitor& visitor) {
 }
 #endif // EMLANG_FEATURE_POINTERS
 
+// ========================================================
+// Helper functions
+// ========================================================
+std::string binOpToString(BinaryOpExpr::BinOp op) {
+    switch (op) {
+        case BinaryOpExpr::BinOp::ADD: return "+";
+        case BinaryOpExpr::BinOp::SUB: return "-";
+        case BinaryOpExpr::BinOp::MUL: return "*";
+        case BinaryOpExpr::BinOp::DIV: return "/";
+        case BinaryOpExpr::BinOp::MOD: return "%";
+        case BinaryOpExpr::BinOp::AND: return "&";
+        case BinaryOpExpr::BinOp::OR: return "|";
+        case BinaryOpExpr::BinOp::XOR: return "^";
+        case BinaryOpExpr::BinOp::INV: return "~";
+        case BinaryOpExpr::BinOp::SHL: return "<<";
+        case BinaryOpExpr::BinOp::SHR: return ">>";
+        case BinaryOpExpr::BinOp::EQ: return "==";
+        case BinaryOpExpr::BinOp::NE: return "!=";
+        case BinaryOpExpr::BinOp::LT: return "<";
+        case BinaryOpExpr::BinOp::LE: return "<=";
+        case BinaryOpExpr::BinOp::GT: return ">";
+        case BinaryOpExpr::BinOp::GE: return ">=";
+        case BinaryOpExpr::BinOp::LAND: return "&&";
+        case BinaryOpExpr::BinOp::LOR: return "||";
+        case BinaryOpExpr::BinOp::LNOT: return "!";
+    }
+    return "";
+}
+
 } // namespace emlang

--- a/compiler/codegen/codegen.cpp
+++ b/compiler/codegen/codegen.cpp
@@ -24,7 +24,9 @@
 namespace emlang {
 namespace codegen {
 
-// ======================== CONSTRUCTION AND LIFECYCLE ========================
+/******************************
+* CONSTRUCTION AND LIFECYCLE
+******************************/
 
 CodeGenerator::CodeGenerator(const std::string& moduleName, OptimizationLevel optLevel) 
     : currentValue(nullptr) {
@@ -37,7 +39,9 @@ CodeGenerator::CodeGenerator(const std::string& moduleName, OptimizationLevel op
     currentExpressionType.clear();
 }
 
-// ======================== PRIMARY CODE GENERATION ========================
+/******************************
+* PRIMARY CODE GENERATION
+******************************/
 
 void CodeGenerator::generateIR(Program& program) {
     program.accept(*this);
@@ -52,7 +56,9 @@ void CodeGenerator::printIR() const {
     contextManager->printIR();
 }
 
-// ======================== EXECUTION ========================
+/******************************
+* EXECUTION
+******************************/
 
 int CodeGenerator::executeMain() {
     return contextManager->executeMain();
@@ -67,54 +73,55 @@ void CodeGenerator::writeCodeToFile(const std::string& filename, bool emitLLVM) 
     }
 }
 
-// ======================== ERROR HANDLING ========================
-
-bool CodeGenerator::hasErrors() const {
-    return errorReporter->hasErrors();
-}
-
-// ======================== HELPER METHODS ========================
-
-void CodeGenerator::error(const std::string& message) {
-    errorReporter->error(CodegenErrorType::InternalError, message);
-    currentValue = nullptr;
-}
-
-void CodeGenerator::error(CodegenErrorType type, const std::string& message, const std::string& context) {
-    errorReporter->error(type, message, context);
-    currentValue = nullptr;
-}
-
 // ========================================================
 // AST Visitor implementations
 // ========================================================
+
+void CodeGenerator::visit(Program& node) {
+    // TODO: Register built-in functions - needs to be implemented
+    // BuiltinsIntegration builtins(*contextManager, *valueMap);
+    // builtins.registerBuiltinFunctions();
+    
+    // Process all statements in the program
+    for (auto& stmt : node.statements) {
+        stmt->accept(*this);
+    }
+    
+    // Verify the module - simplified approach
+    if (llvm::verifyModule(*contextManager->getModule(), &llvm::errs())) {
+        error(CodegenErrorType::InternalError, "Module verification failed");
+    }
+}
+
+/****************************************
+* Visitor - EXPRESSION
+****************************************/
+
 void CodeGenerator::visit(LiteralExpr& node) {
     switch (node.literalType) {
-        case LiteralType::NUMBER:
-            // Check if the number contains a decimal point to determine if it's float or int
-            if (node.value.find('.') != std::string::npos) {
-                // It's a floating point number
-                try {
-                    double floatValue = std::stod(node.value);
-                    currentValue = llvm::ConstantFP::get(contextManager->getContext(), llvm::APFloat(floatValue));
-                    currentExpressionType = "f64";
-                } catch (const std::exception& e) {
-                    error(CodegenErrorType::TypeMismatch, "Invalid floating point number: " + node.value);
-                    return;
-                }
-            } else {
-                // It's an integer
-                try {
-                    int intValue = std::stoi(node.value);
-                    currentValue = llvm::ConstantInt::get(contextManager->getContext(), llvm::APInt(32, intValue, true));
-                    currentExpressionType = "i32";
-                } catch (const std::exception& e) {
-                    error(CodegenErrorType::TypeMismatch, "Invalid integer number: " + node.value);
-                    return;
-                }
+        case LiteralType::INT:
+            // Integer literal
+            try {
+                int intValue = std::stoi(node.value);
+                currentValue = llvm::ConstantInt::get(contextManager->getContext(), llvm::APInt(32, intValue, true));
+                currentExpressionType = "i32";
+            } catch (const std::exception& e) {
+                error(CodegenErrorType::TypeMismatch, "Invalid integer number: " + node.value);
+                return;
             }
             break;
-        case LiteralType::STRING:
+        case LiteralType::FLOAT:
+            // Floating point literal
+            try {
+                double floatValue = std::stod(node.value);
+                currentValue = llvm::ConstantFP::get(contextManager->getContext(), llvm::APFloat(floatValue));
+                currentExpressionType = "f64";
+            } catch (const std::exception& e) {
+                error(CodegenErrorType::TypeMismatch, "Invalid floating point number: " + node.value);
+                return;
+            }
+            break;
+        case LiteralType::STR:
             currentValue = contextManager->getBuilder().CreateGlobalStringPtr(node.value, "str");
             currentExpressionType = "string";
             break;
@@ -152,14 +159,14 @@ void CodeGenerator::visit(LiteralExpr& node) {
             currentExpressionType = "char";
             break;
         }
-        case LiteralType::BOOLEAN:
+        case LiteralType::BOOL:
             currentValue = llvm::ConstantInt::get(contextManager->getContext(), llvm::APInt(1, node.value == "true" ? 1 : 0, false));
             currentExpressionType = "bool";
             break;
-        //case LiteralType::FLOAT
-        //    currentValue = llvm::ConstantFP::get(contextManager->getContext(), llvm::APFloat(std::stod(node.value)));
-        //    currentExpressionType = "f64";
-        //    break;
+        case LiteralType::NULL_LITERAL:
+            currentValue = llvm::ConstantPointerNull::get(llvm::PointerType::getUnqual(contextManager->getContext()));
+            currentExpressionType = "null";
+            break;
         default:
             error(CodegenErrorType::UnknownType, "Unknown literal type");
             break;
@@ -199,36 +206,72 @@ void CodeGenerator::visit(BinaryOpExpr& node) {
     // Generate appropriate instruction based on operator
     auto& builder = contextManager->getBuilder();
     
-    if (node.operator_ == "+") {
-        currentValue = builder.CreateAdd(leftValue, rightValue, "addtmp");
-    } else if (node.operator_ == "-") {
-        currentValue = builder.CreateSub(leftValue, rightValue, "subtmp");
-    } else if (node.operator_ == "*") {
-        currentValue = builder.CreateMul(leftValue, rightValue, "multmp");
-    } else if (node.operator_ == "/") {
-        currentValue = builder.CreateSDiv(leftValue, rightValue, "divtmp");
-    } else if (node.operator_ == "%") {
-        currentValue = builder.CreateSRem(leftValue, rightValue, "modtmp");
-    } else if (node.operator_ == "<") {
-        currentValue = builder.CreateICmpSLT(leftValue, rightValue, "cmptmp");
-        currentExpressionType = "bool";
-    } else if (node.operator_ == ">") {
-        currentValue = builder.CreateICmpSGT(leftValue, rightValue, "cmptmp");
-        currentExpressionType = "bool";
-    } else if (node.operator_ == "<=") {
-        currentValue = builder.CreateICmpSLE(leftValue, rightValue, "cmptmp");
-        currentExpressionType = "bool";
-    } else if (node.operator_ == ">=") {
-        currentValue = builder.CreateICmpSGE(leftValue, rightValue, "cmptmp");
-        currentExpressionType = "bool";
-    } else if (node.operator_ == "==") {
-        currentValue = builder.CreateICmpEQ(leftValue, rightValue, "cmptmp");
-        currentExpressionType = "bool";
-    } else if (node.operator_ == "!=") {
-        currentValue = builder.CreateICmpNE(leftValue, rightValue, "cmptmp");
-        currentExpressionType = "bool";
-    } else {
-        error(CodegenErrorType::TypeMismatch, "Unknown binary operator: " + node.operator_);
+    switch (node.operator_) {
+        case BinaryOpExpr::BinOp::ADD:
+            currentValue = builder.CreateAdd(leftValue, rightValue, "addtmp");
+            break;
+        case BinaryOpExpr::BinOp::SUB:
+            currentValue = builder.CreateSub(leftValue, rightValue, "subtmp");
+            break;
+        case BinaryOpExpr::BinOp::MUL:
+            currentValue = builder.CreateMul(leftValue, rightValue, "multmp");
+            break;
+        case BinaryOpExpr::BinOp::DIV:
+            currentValue = builder.CreateSDiv(leftValue, rightValue, "divtmp");
+            break;
+        case BinaryOpExpr::BinOp::MOD:
+            currentValue = builder.CreateSRem(leftValue, rightValue, "modtmp");
+            break;
+        case BinaryOpExpr::BinOp::LT:
+            currentValue = builder.CreateICmpSLT(leftValue, rightValue, "cmptmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::GT:
+            currentValue = builder.CreateICmpSGT(leftValue, rightValue, "cmptmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::LE:
+            currentValue = builder.CreateICmpSLE(leftValue, rightValue, "cmptmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::GE:
+            currentValue = builder.CreateICmpSGE(leftValue, rightValue, "cmptmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::EQ:
+            currentValue = builder.CreateICmpEQ(leftValue, rightValue, "cmptmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::NE:
+            currentValue = builder.CreateICmpNE(leftValue, rightValue, "cmptmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::LAND:
+            currentValue = builder.CreateAnd(leftValue, rightValue, "landtmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::LOR:
+            currentValue = builder.CreateOr(leftValue, rightValue, "lortmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::AND:
+            currentValue = builder.CreateAnd(leftValue, rightValue, "andtmp");
+            break;
+        case BinaryOpExpr::BinOp::OR:
+            currentValue = builder.CreateOr(leftValue, rightValue, "ortmp");
+            break;
+        case BinaryOpExpr::BinOp::XOR:
+            currentValue = builder.CreateXor(leftValue, rightValue, "xortmp");
+            break;
+        case BinaryOpExpr::BinOp::SHL:
+            currentValue = builder.CreateShl(leftValue, rightValue, "shltmp");
+            break;
+        case BinaryOpExpr::BinOp::SHR:
+            currentValue = builder.CreateLShr(leftValue, rightValue, "shrtmp");
+            break;
+        default:
+            error(CodegenErrorType::TypeMismatch, "Unknown binary operator");
+            break;
     }
 }
 
@@ -244,14 +287,64 @@ void CodeGenerator::visit(UnaryOpExpr& node) {
     
     auto& builder = contextManager->getBuilder();
     
-    if (node.operator_ == "-") {
-        currentValue = builder.CreateNeg(operandValue, "negtmp");
-    } else if (node.operator_ == "!") {
-        currentValue = builder.CreateNot(operandValue, "nottmp");
-        currentExpressionType = "bool";
-    } else {
-        error(CodegenErrorType::TypeMismatch, "Unknown unary operator: " + node.operator_);
+    switch (node.operator_) {
+        case BinaryOpExpr::BinOp::SUB:  // Negation uses SUB operator
+            currentValue = builder.CreateNeg(operandValue, "negtmp");
+            break;
+        case BinaryOpExpr::BinOp::LNOT:  // Logical NOT
+            currentValue = builder.CreateNot(operandValue, "nottmp");
+            currentExpressionType = "bool";
+            break;
+        case BinaryOpExpr::BinOp::INV:   // Bitwise NOT
+            currentValue = builder.CreateNot(operandValue, "invtmp");
+            break;
+        default:
+            error(CodegenErrorType::TypeMismatch, "Unknown unary operator");
+            break;
     }
+}
+
+void CodeGenerator::visit(AssignmentExpr& node) {
+    // First, determine where we're storing the value (target)
+    // This depends on the type of target - it could be a variable name or a dereferenced pointer
+    llvm::Value* targetPtr = nullptr;
+    
+    if (auto* identExpr = dynamic_cast<IdentifierExpr*>(node.target.get())) {
+        // Target is a simple variable
+        targetPtr = valueMap->getVariable(identExpr->name);
+        if (!targetPtr) {
+            error(CodegenErrorType::UndefinedSymbol, "Unknown variable name in assignment: " + identExpr->name);
+            return;
+        }
+#ifdef EMLANG_FEATURE_POINTERS
+    } else if (auto* derefExpr = dynamic_cast<DereferenceExpr*>(node.target.get())) {
+        // Target is a dereference expression (*ptr) - we need to get the pointer value
+        derefExpr->operand->accept(*this);
+        targetPtr = currentValue;
+        if (!targetPtr) {
+            error(CodegenErrorType::InternalError, "Invalid pointer dereference in assignment");
+            return;
+        }
+#endif // EMLANG_FEATURE_POINTERS
+    } else {
+        error(CodegenErrorType::TypeMismatch, "Invalid assignment target type");
+        return;
+    }
+    
+    // Now evaluate the right-hand side to get the value to store
+    node.value->accept(*this);
+    llvm::Value* valueToStore = currentValue;
+    if (!valueToStore) {
+        error(CodegenErrorType::InternalError, "Invalid expression in assignment");
+        return;
+    }
+    
+    // Create a store instruction to assign the value using context manager's builder
+    auto& builder = contextManager->getBuilder();
+    builder.CreateStore(valueToStore, targetPtr);
+    
+    // The value of the assignment expression is the value assigned
+    currentValue = valueToStore;
 }
 
 void CodeGenerator::visit(FunctionCallExpr& node) {
@@ -295,12 +388,270 @@ void CodeGenerator::visit(FunctionCallExpr& node) {
     }
 }
 
+void CodeGenerator::visit(MemberExpr& node) {
+    // Generate object expression
+    node.object->accept(*this);
+    llvm::Value* objectValue = currentValue;
+    
+    if (!objectValue) {
+        error(CodegenErrorType::InternalError, "Invalid object in member access");
+        return;
+    }
+    
+    // TODO: Implement proper struct/object member access
+    // For now, this is a placeholder implementation
+    error(CodegenErrorType::UnknownType, "Member access not yet fully implemented");
+    currentValue = nullptr;
+}
+
+#ifdef EMLANG_FEATURE_CASTING
+void CodeGenerator::visit(CastExpr& node) {
+    // Generate operand expression
+    node.operand->accept(*this);
+    llvm::Value* operandValue = currentValue;
+    std::string sourceType = currentExpressionType;
+    
+    if (!operandValue) {
+        error(CodegenErrorType::InternalError, "Invalid operand in cast expression");
+        return;
+    }
+    
+    // Get source and target LLVM types
+    llvm::Type* sourceLLVMType = operandValue->getType();
+    llvm::Type* targetLLVMType = valueMap->getLLVMType(node.targetType, *contextManager);
+    
+    if (!targetLLVMType) {
+        error(CodegenErrorType::UnknownType, "Unknown target type in cast: " + node.targetType);
+        return;
+    }
+    
+    auto& builder = contextManager->getBuilder();
+    
+    // Perform appropriate cast based on types
+    if (sourceLLVMType == targetLLVMType) {
+        // No cast needed
+        currentValue = operandValue;
+    } else if (sourceLLVMType->isIntegerTy() && targetLLVMType->isIntegerTy()) {
+        // Integer to integer cast
+        unsigned sourceBits = sourceLLVMType->getIntegerBitWidth();
+        unsigned targetBits = targetLLVMType->getIntegerBitWidth();
+        
+        if (sourceBits < targetBits) {
+            // Sign extend
+            currentValue = builder.CreateSExt(operandValue, targetLLVMType, "sext");
+        } else if (sourceBits > targetBits) {
+            // Truncate
+            currentValue = builder.CreateTrunc(operandValue, targetLLVMType, "trunc");
+        } else {
+            // Bitcast
+            currentValue = builder.CreateBitCast(operandValue, targetLLVMType, "bitcast");
+        }
+    } else if (sourceLLVMType->isIntegerTy() && targetLLVMType->isFloatingPointTy()) {
+        // Integer to float
+        currentValue = builder.CreateSIToFP(operandValue, targetLLVMType, "sitofp");
+    } else if (sourceLLVMType->isFloatingPointTy() && targetLLVMType->isIntegerTy()) {
+        // Float to integer
+        currentValue = builder.CreateFPToSI(operandValue, targetLLVMType, "fptosi");
+    } else if (sourceLLVMType->isFloatingPointTy() && targetLLVMType->isFloatingPointTy()) {
+        // Float to float
+        unsigned sourceBits = sourceLLVMType->getPrimitiveSizeInBits();
+        unsigned targetBits = targetLLVMType->getPrimitiveSizeInBits();
+        
+        if (sourceBits < targetBits) {
+            currentValue = builder.CreateFPExt(operandValue, targetLLVMType, "fpext");
+        } else if (sourceBits > targetBits) {
+            currentValue = builder.CreateFPTrunc(operandValue, targetLLVMType, "fptrunc");
+        } else {
+            currentValue = operandValue;
+        }
+    } else if (sourceLLVMType->isPointerTy() && targetLLVMType->isPointerTy()) {
+        // Pointer to pointer cast
+        currentValue = builder.CreateBitCast(operandValue, targetLLVMType, "ptrcast");
+    } else if (sourceLLVMType->isIntegerTy() && targetLLVMType->isPointerTy()) {
+        // Integer to pointer (dangerous but allowed in explicit casts)
+        currentValue = builder.CreateIntToPtr(operandValue, targetLLVMType, "inttoptr");
+    } else if (sourceLLVMType->isPointerTy() && targetLLVMType->isIntegerTy()) {
+        // Pointer to integer
+        currentValue = builder.CreatePtrToInt(operandValue, targetLLVMType, "ptrtoint");
+    } else {
+        // Unsupported cast
+        error(CodegenErrorType::TypeMismatch, "Unsupported cast from " + sourceType + " to " + node.targetType);
+        return;
+    }
+      currentExpressionType = node.targetType;
+}
+#endif // EMLANG_FEATURE_CASTING
+
+void CodeGenerator::visit(IndexExpr& node) {
+    // Generate array expression
+    node.array->accept(*this);
+    llvm::Value* arrayValue = currentValue;
+    std::string arrayType = currentExpressionType;
+    
+    // Generate index expression
+    node.index->accept(*this);
+    llvm::Value* indexValue = currentValue;
+    
+    if (!arrayValue || !indexValue) {
+        error(CodegenErrorType::InternalError, "Invalid array or index in array access");
+        return;
+    }
+    
+    auto& builder = contextManager->getBuilder();
+    
+    // Create GEP (GetElementPtr) instruction for array access
+    std::vector<llvm::Value*> indices;
+    indices.push_back(llvm::ConstantInt::get(contextManager->getContext(), llvm::APInt(32, 0, true))); // First index (array base)
+    indices.push_back(indexValue); // Second index (element)
+    
+    // Get array element type
+    llvm::Type* elementType = arrayValue->getType();
+    if (auto ptrType = llvm::dyn_cast<llvm::PointerType>(elementType)) {
+        // In LLVM 20+, use opaque pointers - we need type information from our type system
+        elementType = valueMap->getLLVMType("i32", *contextManager); // Default fallback
+        if (!arrayType.empty() && arrayType.back() == ']') {
+            size_t bracketPos = arrayType.find('[');
+            if (bracketPos != std::string::npos) {
+                std::string baseType = arrayType.substr(0, bracketPos);
+                elementType = valueMap->getLLVMType(baseType, *contextManager);
+            }
+        }
+    }
+    
+    // Create GEP and load
+    llvm::Value* elementPtr = builder.CreateGEP(elementType, arrayValue, indices, "arrayidx");
+    currentValue = builder.CreateLoad(elementType, elementPtr, "arrayload");
+    
+    // Update expression type - remove array brackets if present
+    if (arrayType.back() == ']') {
+        size_t bracketPos = arrayType.find('[');
+        if (bracketPos != std::string::npos) {
+            currentExpressionType = arrayType.substr(0, bracketPos);
+        }
+    } else {
+        currentExpressionType = "i32"; // Fallback type
+    }
+}
+
+void CodeGenerator::visit(ArrayExpr& node) {
+    if (node.elements.empty()) {
+        error(CodegenErrorType::TypeMismatch, "Empty array literals not supported");
+        return;
+    }
+    
+    // Generate all elements and determine common type
+    std::vector<llvm::Value*> elementValues;
+    std::string elementType;
+    
+    for (auto& element : node.elements) {
+        element->accept(*this);
+        if (currentValue) {
+            elementValues.push_back(currentValue);
+            if (elementType.empty()) {
+                elementType = currentExpressionType;
+            }
+        } else {
+            error(CodegenErrorType::InternalError, "Invalid element in array literal");
+            return;
+        }
+    }
+    
+    // Get LLVM element type
+    llvm::Type* llvmElementType = valueMap->getLLVMType(elementType, *contextManager);
+    if (!llvmElementType) {
+        llvmElementType = llvm::Type::getInt32Ty(contextManager->getContext());
+    }
+    
+    // Create array type
+    llvm::ArrayType* arrayType = llvm::ArrayType::get(llvmElementType, elementValues.size());
+    
+    // Create alloca for array
+    auto& builder = contextManager->getBuilder();
+    llvm::IRBuilder<> tmpBuilder(&currentFunction->getEntryBlock(), currentFunction->getEntryBlock().begin());
+    llvm::Value* arrayAlloca = tmpBuilder.CreateAlloca(arrayType, nullptr, "arraytmp");
+    
+    // Store each element
+    for (size_t i = 0; i < elementValues.size(); ++i) {
+        std::vector<llvm::Value*> indices;
+        indices.push_back(llvm::ConstantInt::get(contextManager->getContext(), llvm::APInt(32, 0, true)));
+        indices.push_back(llvm::ConstantInt::get(contextManager->getContext(), llvm::APInt(32, i, true)));
+        
+        llvm::Value* elementPtr = builder.CreateGEP(arrayType, arrayAlloca, indices, "arrayelem");
+        builder.CreateStore(elementValues[i], elementPtr);
+    }
+    
+    currentValue = arrayAlloca;
+    currentExpressionType = elementType + "[" + std::to_string(elementValues.size()) + "]";
+}
+
+void CodeGenerator::visit(ObjectExpr& node) {
+    // TODO: Implement proper object literal support
+    // For now, this is a placeholder implementation
+    error(CodegenErrorType::UnknownType, "Object literals not yet implemented");
+    currentValue = nullptr;
+}
+
+#ifdef EMLANG_FEATURE_POINTERS
+void CodeGenerator::visit(DereferenceExpr& node) {
+    // Visit the operand to get the pointer value
+    node.operand->accept(*this);
+    llvm::Value* ptrValue = currentValue;
+    std::string operandType = currentExpressionType;
+    
+    if (!ptrValue) {
+        error(CodegenErrorType::InternalError, "Invalid pointer value for dereference");
+        return;
+    }
+    
+    // Determine the element type from the pointer type using value map
+    llvm::Type* elementType = valueMap->getElementTypeFromPointer(ptrValue, operandType, *contextManager);
+    
+    if (!elementType) {
+        // Fallback to int32 for backward compatibility
+        elementType = llvm::Type::getInt32Ty(contextManager->getContext());
+        currentExpressionType = "i32";
+    } else {
+        // Update current expression type to the pointee type using value map
+        currentExpressionType = valueMap->getPointeeType(operandType);
+    }
+    
+    // Create load instruction to dereference pointer using context manager's builder
+    auto& builder = contextManager->getBuilder();
+    currentValue = builder.CreateLoad(elementType, ptrValue, "deref");
+}
+
+void CodeGenerator::visit(AddressOfExpr& node) {
+    // For address-of operation, we need the address of a variable
+    if (auto identifier = dynamic_cast<IdentifierExpr*>(node.operand.get())) {
+        llvm::Value* value = valueMap->getVariable(identifier->name);
+        if (value) {
+            // value map stores alloca instructions (addresses)
+            currentValue = value;
+              // Set the expression type to pointer of the variable type using value map
+            std::string variableType = valueMap->getVariableType(identifier->name);
+            currentExpressionType = variableType + "*";
+        } else {
+            error(CodegenErrorType::UndefinedSymbol, "Undefined variable for address-of: " + identifier->name);
+            currentValue = nullptr;
+        }
+    } else {
+        error(CodegenErrorType::TypeMismatch, "Address-of operation only supported for variables");
+        currentValue = nullptr;
+    }
+}
+#endif // EMLANG_FEATURE_POINTERS
+
+/****************************************
+* Visitor - DECLARATIONS
+****************************************/
+
 void CodeGenerator::visit(VariableDecl& node) {
     // Get LLVM type using value map
-    llvm::Type* llvmType = valueMap->getLLVMType(node.type, *contextManager);
+    std::string typeStr = node.type.value_or("i32"); // Default to i32 if no type specified
+    llvm::Type* llvmType = valueMap->getLLVMType(typeStr, *contextManager);
     
     // Track the type for multi-level pointer support
-    currentExpressionType = node.type;
+    currentExpressionType = typeStr;
     
     // Check if we're in global scope (no current function)
     if (!currentFunction) {
@@ -336,9 +687,8 @@ void CodeGenerator::visit(VariableDecl& node) {
             initVal,
             node.name
         );
-        
-        // Remember the global variable in value map
-        valueMap->addVariable(node.name, globalVar, node.type);
+          // Remember the global variable in value map
+        valueMap->addVariable(node.name, globalVar, typeStr);
         currentValue = globalVar;
     } else {
         // Local variable
@@ -371,22 +721,33 @@ void CodeGenerator::visit(VariableDecl& node) {
         
         // Store initial value using context manager's builder
         contextManager->getBuilder().CreateStore(initVal, alloca);
-        
-        // Remember the variable in value map
-        valueMap->addVariable(node.name, alloca, node.type);
+          // Remember the variable in value map
+        valueMap->addVariable(node.name, alloca, typeStr);
         currentValue = alloca;
     }
 }
 
-void CodeGenerator::visit(FunctionDecl& node) {
+void CodeGenerator::visit(FunctionDecl& node) {    
     // Create function type using value map
     std::vector<llvm::Type*> paramTypes;
     for (const auto& param : node.parameters) {
-        paramTypes.push_back(valueMap->getLLVMType(param.type, *contextManager));
+        llvm::Type* paramType = valueMap->getLLVMType(param.type, *contextManager);
+        if (!paramType) {
+            error(CodegenErrorType::UnknownType, "Unknown parameter type: " + param.type + " in function: " + node.name);
+            return;
+        }
+        paramTypes.push_back(paramType);
     }
     
-    llvm::Type* returnType = valueMap->getLLVMType(node.returnType, *contextManager);
-      // Create function type
+    std::string returnTypeStr = node.returnType.value_or("void"); // Default to void if no return type
+    llvm::Type* returnType = valueMap->getLLVMType(returnTypeStr, *contextManager);
+    
+    if (!returnType) {
+        error(CodegenErrorType::UnknownType, "Unknown return type: " + returnTypeStr + " in function: " + node.name);
+        return;
+    }
+    
+    // Create function type
     llvm::FunctionType* funcType = llvm::FunctionType::get(returnType, paramTypes, false);
     
     // Create function
@@ -487,6 +848,10 @@ void CodeGenerator::visit(ExternFunctionDecl& node) {
     
     currentValue = function;
 }
+
+/****************************************
+* Visitor - STATEMENTS
+****************************************/
 
 void CodeGenerator::visit(BlockStmt& node) {
     auto prevNamedValues = valueMap->saveScope(); // Enter new scope for block
@@ -595,6 +960,74 @@ void CodeGenerator::visit(WhileStmt& node) {
     builder.SetInsertPoint(afterBB);
 }
 
+void CodeGenerator::visit(ForStmt& node) {
+    auto& builder = contextManager->getBuilder();
+    llvm::Function* function = builder.GetInsertBlock()->getParent();
+    
+    // Create basic blocks
+    llvm::BasicBlock* initBB = llvm::BasicBlock::Create(contextManager->getContext(), "forinit", function);
+    llvm::BasicBlock* condBB = llvm::BasicBlock::Create(contextManager->getContext(), "forcond", function);
+    llvm::BasicBlock* loopBB = llvm::BasicBlock::Create(contextManager->getContext(), "forloop", function);
+    llvm::BasicBlock* incBB = llvm::BasicBlock::Create(contextManager->getContext(), "forinc", function);
+    llvm::BasicBlock* afterBB = llvm::BasicBlock::Create(contextManager->getContext(), "afterfor", function);
+    
+    // Enter new scope for loop variables
+    auto prevNamedValues = valueMap->saveScope();
+    
+    // Jump to initialization
+    builder.CreateBr(initBB);
+    
+    // Generate initialization
+    builder.SetInsertPoint(initBB);
+    if (node.initializer) {
+        node.initializer->accept(*this);
+    }
+    builder.CreateBr(condBB);
+    
+    // Generate condition block
+    builder.SetInsertPoint(condBB);
+    llvm::Value* condV = nullptr;
+    if (node.condition) {
+        node.condition->accept(*this);
+        condV = currentValue;
+        if (condV && condV->getType() != llvm::Type::getInt1Ty(contextManager->getContext())) {
+            condV = builder.CreateICmpNE(condV, llvm::ConstantInt::get(condV->getType(), 0), "forcond");
+        }
+    } else {
+        // Infinite loop if no condition
+        condV = llvm::ConstantInt::getTrue(contextManager->getContext());
+    }
+    
+    if (condV) {
+        builder.CreateCondBr(condV, loopBB, afterBB);
+    } else {
+        builder.CreateBr(afterBB);
+    }
+    
+    // Generate loop body
+    builder.SetInsertPoint(loopBB);
+    if (node.body) {
+        node.body->accept(*this);
+    }
+    
+    if (!builder.GetInsertBlock()->getTerminator()) {
+        builder.CreateBr(incBB);
+    }
+    
+    // Generate increment
+    builder.SetInsertPoint(incBB);
+    if (node.increment) {
+        node.increment->accept(*this);
+    }
+    builder.CreateBr(condBB);
+    
+    // Continue after loop
+    builder.SetInsertPoint(afterBB);
+    
+    // Exit scope for loop variables
+    valueMap->restoreScope(prevNamedValues);
+}
+
 void CodeGenerator::visit(ReturnStmt& node) {
     auto& builder = contextManager->getBuilder();
     
@@ -614,109 +1047,21 @@ void CodeGenerator::visit(ExpressionStmt& node) {
     node.expression->accept(*this);
 }
 
-void CodeGenerator::visit(DereferenceExpr& node) {
-    // Visit the operand to get the pointer value
-    node.operand->accept(*this);
-    llvm::Value* ptrValue = currentValue;
-    std::string operandType = currentExpressionType;
-    
-    if (!ptrValue) {
-        error(CodegenErrorType::InternalError, "Invalid pointer value for dereference");
-        return;
-    }
-    
-    // Determine the element type from the pointer type using value map
-    llvm::Type* elementType = valueMap->getElementTypeFromPointer(ptrValue, operandType, *contextManager);
-    
-    if (!elementType) {
-        // Fallback to int32 for backward compatibility
-        elementType = llvm::Type::getInt32Ty(contextManager->getContext());
-        currentExpressionType = "i32";
-    } else {
-        // Update current expression type to the pointee type using value map
-        currentExpressionType = valueMap->getPointeeType(operandType);
-    }
-    
-    // Create load instruction to dereference pointer using context manager's builder
-    auto& builder = contextManager->getBuilder();
-    currentValue = builder.CreateLoad(elementType, ptrValue, "deref");
+/******************************
+* ERROR HANDLING
+******************************/
+bool CodeGenerator::hasErrors() const {
+    return errorReporter->hasErrors();
 }
 
-void CodeGenerator::visit(AddressOfExpr& node) {
-    // For address-of operation, we need the address of a variable
-    if (auto identifier = dynamic_cast<IdentifierExpr*>(node.operand.get())) {
-        llvm::Value* value = valueMap->getVariable(identifier->name);
-        if (value) {
-            // value map stores alloca instructions (addresses)
-            currentValue = value;
-              // Set the expression type to pointer of the variable type using value map
-            std::string variableType = valueMap->getVariableType(identifier->name);
-            currentExpressionType = variableType + "*";
-        } else {
-            error(CodegenErrorType::UndefinedSymbol, "Undefined variable for address-of: " + identifier->name);
-            currentValue = nullptr;
-        }
-    } else {
-        error(CodegenErrorType::TypeMismatch, "Address-of operation only supported for variables");
-        currentValue = nullptr;
-    }
+void CodeGenerator::error(const std::string& message) {
+    errorReporter->error(CodegenErrorType::InternalError, message);
+    currentValue = nullptr;
 }
 
-void CodeGenerator::visit(AssignmentExpr& node) {
-    // First, determine where we're storing the value (target)
-    // This depends on the type of target - it could be a variable name or a dereferenced pointer
-    llvm::Value* targetPtr = nullptr;
-    
-    if (auto* identExpr = dynamic_cast<IdentifierExpr*>(node.target.get())) {
-        // Target is a simple variable
-        targetPtr = valueMap->getVariable(identExpr->name);
-        if (!targetPtr) {
-            error(CodegenErrorType::UndefinedSymbol, "Unknown variable name in assignment: " + identExpr->name);
-            return;
-        }
-    } else if (auto* derefExpr = dynamic_cast<DereferenceExpr*>(node.target.get())) {
-        // Target is a dereference expression (*ptr) - we need to get the pointer value
-        derefExpr->operand->accept(*this);
-        targetPtr = currentValue;
-        if (!targetPtr) {
-            error(CodegenErrorType::InternalError, "Invalid pointer dereference in assignment");
-            return;
-        }
-    } else {
-        error(CodegenErrorType::TypeMismatch, "Invalid assignment target type");
-        return;
-    }
-    
-    // Now evaluate the right-hand side to get the value to store
-    node.value->accept(*this);
-    llvm::Value* valueToStore = currentValue;
-    if (!valueToStore) {
-        error(CodegenErrorType::InternalError, "Invalid expression in assignment");
-        return;
-    }
-    
-    // Create a store instruction to assign the value using context manager's builder
-    auto& builder = contextManager->getBuilder();
-    builder.CreateStore(valueToStore, targetPtr);
-    
-    // The value of the assignment expression is the value assigned
-    currentValue = valueToStore;
-}
-
-void CodeGenerator::visit(Program& node) {
-    // TODO: Register built-in functions - needs to be implemented
-    // BuiltinsIntegration builtins(*contextManager, *valueMap);
-    // builtins.registerBuiltinFunctions();
-    
-    // Process all statements in the program
-    for (auto& stmt : node.statements) {
-        stmt->accept(*this);
-    }
-    
-    // Verify the module - simplified approach
-    if (llvm::verifyModule(*contextManager->getModule(), &llvm::errs())) {
-        error(CodegenErrorType::InternalError, "Module verification failed");
-    }
+void CodeGenerator::error(CodegenErrorType type, const std::string& message, const std::string& context) {
+    errorReporter->error(type, message, context);
+    currentValue = nullptr;
 }
 
 } // namespace codegen

--- a/compiler/parser/parser.cpp
+++ b/compiler/parser/parser.cpp
@@ -111,6 +111,16 @@ std::unique_ptr<Program> Parser::parseProgram() {
 
 StatementPtr Parser::parseStatement() {
     try {
+        // Skip newlines and handle empty lines
+        while (match(TokenType::NEWLINE)) {
+            // Skip newlines - continue to next statement
+        }
+        
+        // Check if we've reached the end after skipping newlines
+        if (isAtEnd()) {
+            return nullptr;
+        }
+        
         // Standard declarations
         if (match(TokenType::LET) || match(TokenType::CONST)) {
             current--; // Back up to re-read the token
@@ -155,8 +165,15 @@ StatementPtr Parser::parseStatement() {
             return parseBlockStatement();
         }
         
-        // Default to expression statement
-        return parseExpressionStatement();
+        // Check for tokens that should not start an expression statement
+        if (check(TokenType::RIGHT_BRACE) || check(TokenType::EOF_TOKEN)) {
+            return nullptr;
+        }
+        
+        // Default to expression statement - parse an expression followed by semicolon
+        auto expr = parseExpression();
+        consume(TokenType::SEMICOLON, "Expected ';' after expression");
+        return std::make_unique<ExpressionStmt>(std::move(expr));
         
     } catch (const ParseError& e) {
         synchronize();

--- a/include/ast/expr.h
+++ b/include/ast/expr.h
@@ -300,31 +300,7 @@ public:
 * Helper functions for expression creation
 ****************************************/
 /* BinOp to string method */
-std::string binOpToString(BinaryOpExpr::BinOp op) {
-    switch (op) {
-        case BinaryOpExpr::BinOp::ADD: return "+";
-        case BinaryOpExpr::BinOp::SUB: return "-";
-        case BinaryOpExpr::BinOp::MUL: return "*";
-        case BinaryOpExpr::BinOp::DIV: return "/";
-        case BinaryOpExpr::BinOp::MOD: return "%";
-        case BinaryOpExpr::BinOp::AND: return "&";
-        case BinaryOpExpr::BinOp::OR: return "|";
-        case BinaryOpExpr::BinOp::XOR: return "^";
-        case BinaryOpExpr::BinOp::INV: return "~";
-        case BinaryOpExpr::BinOp::SHL: return "<<";
-        case BinaryOpExpr::BinOp::SHR: return ">>";
-        case BinaryOpExpr::BinOp::EQ: return "==";
-        case BinaryOpExpr::BinOp::NE: return "!=";
-        case BinaryOpExpr::BinOp::LT: return "<";
-        case BinaryOpExpr::BinOp::LE: return "<=";
-        case BinaryOpExpr::BinOp::GT: return ">";
-        case BinaryOpExpr::BinOp::GE: return ">=";
-        case BinaryOpExpr::BinOp::LAND: return "&&";
-        case BinaryOpExpr::BinOp::LOR: return "||";
-        case BinaryOpExpr::BinOp::LNOT: return "!";
-    }
-    return "";
-}
+std::string binOpToString(BinaryOpExpr::BinOp op);
 
 } // namespace emlang
 


### PR DESCRIPTION
## What does this pull request aim to solve?

This pull request introduces several changes across multiple files to improve code organization, enhance parsing logic, and expand functionality in the code generation module. Key updates include refactoring helper functions, improving statement parsing, and adding new visitor methods for AST traversal.

### Refactoring and Code Organization:

* Moved the `binOpToString` function from `include/ast/expr.h` to `compiler/ast/expr.cpp` to better align implementation with the corresponding source file. The function converts binary operators to their string representations. [[1]](diffhunk://#diff-53c1ef951c8b767e77ef947a1a42ba654881b40cf5b10535b430626b9cd46788L303-R303) [[2]](diffhunk://#diff-f4bcff59b66e054033a371125fee0976f38eb6d4be9192ecdf10079d23320ea6R207-R235)

### Parsing Logic Enhancements:

* Updated `Parser::parseStatement` in `compiler/parser/parser.cpp` to skip newlines and handle empty lines gracefully, ensuring proper parsing even when encountering consecutive newlines.
* Improved parsing of expression statements by adding checks for invalid starting tokens (`RIGHT_BRACE` and `EOF_TOKEN`) and ensuring semicolons follow expressions.

### Code Generation Improvements:

* Added private members (`contextManager`, `valueMap`, `errorReporter`, `currentValue`, `currentExpressionType`, and `currentFunction`) to the `CodeGenerator` class in `include/codegen/codegen.h` to support enhanced code generation capabilities.
* Expanded the `CodeGenerator` class with new visitor methods for additional AST nodes, including `AssignmentExpr`, `MemberExpr`, `CastExpr`, `IndexExpr`, `ArrayExpr`, and `ObjectExpr`, among others. This improves the flexibility and scope of AST traversal.